### PR TITLE
feat: add Intelligent useEffect vs useLayoutEffect

### DIFF
--- a/.grit/patterns/js/intelligent_useEffect_to_useLayoutEffect.md
+++ b/.grit/patterns/js/intelligent_useEffect_to_useLayoutEffect.md
@@ -1,0 +1,109 @@
+---
+title: [React2Hooks] Intelligent useEffect vs useLayoutEffect
+---
+
+If a useEffect depends on layout etc. it should switch to useLayoutEffect.
+
+tags: #fix
+
+```grit
+engine marzano(0.1)
+language js
+
+
+or {
+
+ `useEffect(() => {
+    $body 
+    },[$conditions])` as $effectHook where {
+    $body <: contains `current`,
+    $effectHook => `useLayoutEffect(() => {
+    $body
+},[$conditions])`
+ },
+ 
+ `React.useEffect(() => {
+    $body 
+    },[$conditions])` as $effectHook where {
+    $body <: contains `current`,
+    $effectHook => `React.useLayoutEffect(() => {
+    $body
+  },[$conditions])`
+ },
+
+ `useEffect(() => {
+    $body 
+    })` as $effectHook where {
+    $body <: contains `current`,
+    $effectHook => `useLayoutEffect(() => {
+    $body
+})`
+ },
+ 
+ `React.useEffect(() => {
+  $body 
+  })` as $effectHook where {
+  $body <: contains `current`,
+  $effectHook => `React.useLayoutEffect(() => {
+  $body
+})`
+},
+
+}
+```
+
+## useEffect with conditions
+
+```javascript
+useEffect(() => {
+  ref.current = 'some value'
+},[])
+```
+
+```javascript
+useLayoutEffect(() => {
+  ref.current = 'some value'
+},[])
+```
+
+## React.useEffect with conditions
+
+```javascript
+React.useEffect(() => {
+  ref.current = 'some value'
+},[])
+```
+
+```javascript
+React.useLayoutEffect(() => {
+  ref.current = 'some value'
+},[])
+```
+
+## useEffect without conditions
+
+```javascript
+useEffect(() => {
+  ref.current = 'some value'
+})
+```
+
+```javascript
+useLayoutEffect(() => {
+  ref.current = 'some value'
+})
+```
+
+## React.useEffect without conditions
+
+```javascript
+React.useEffect(() => {
+  ref.current = 'some value'
+})
+```
+
+```javascript
+React.useLayoutEffect(() => {
+  ref.current = 'some value'
+})
+```

--- a/.grit/patterns/js/intelligent_useEffect_to_useLayoutEffect.md
+++ b/.grit/patterns/js/intelligent_useEffect_to_useLayoutEffect.md
@@ -12,43 +12,14 @@ language js
 
 
 or {
-
- `useEffect(() => {
-    $body 
-    },[$conditions])` as $effectHook where {
-    $body <: contains `current`,
-    $effectHook => `useLayoutEffect(() => {
-    $body
-},[$conditions])`
- },
- 
- `React.useEffect(() => {
-    $body 
-    },[$conditions])` as $effectHook where {
-    $body <: contains `current`,
-    $effectHook => `React.useLayoutEffect(() => {
-    $body
-  },[$conditions])`
- },
-
- `useEffect(() => {
-    $body 
-    })` as $effectHook where {
-    $body <: contains `current`,
-    $effectHook => `useLayoutEffect(() => {
-    $body
-})`
- },
- 
- `React.useEffect(() => {
-  $body 
-  })` as $effectHook where {
-  $body <: contains `current`,
-  $effectHook => `React.useLayoutEffect(() => {
-  $body
-})`
-},
-
+ `useEffect($body)` as $effectHook where {
+    $body <: contains `document.$method`,
+    $effectHook => `useLayoutEffect($body)`
+  },
+ `React.useEffect($body)` as $effectHook where {
+  $body <: contains `document.$method`,
+  $effectHook => `React.useLayoutEffect($body)`
+ }
 }
 ```
 
@@ -56,27 +27,67 @@ or {
 
 ```javascript
 useEffect(() => {
-  ref.current = 'some value'
+    // DOM Query Methods:
+    // 1. getElementById
+    const elementById = document.getElementById('myElementId');
+    console.log('Element by ID:', elementById);
+   
+    // 2. getElementsByClassName
+    const elementsByClass = document.getElementsByClassName('myClass');
+    console.log('Elements by Class:', elementsByClass);
+
+    // 3. querySelector
+    const elementBySelector = document.querySelector('.mySelector');
+    console.log('Element by Selector:', elementBySelector);
+}, []); 
+
+useEffect(() => {
+    ref.current = 'some value'
 },[])
+
+useEffect(() => {
+    console.log("useEffect")
+},[]);
 ```
 
 ```javascript
 useLayoutEffect(() => {
-  ref.current = 'some value'
+    // DOM Query Methods:
+    // 1. getElementById
+    const elementById = document.getElementById('myElementId');
+    console.log('Element by ID:', elementById);
+   
+    // 2. getElementsByClassName
+    const elementsByClass = document.getElementsByClassName('myClass');
+    console.log('Elements by Class:', elementsByClass);
+
+    // 3. querySelector
+    const elementBySelector = document.querySelector('.mySelector');
+    console.log('Element by Selector:', elementBySelector);
+}, []); 
+
+useEffect(() => {
+    ref.current = 'some value'
 },[])
+
+useEffect(() => {
+    console.log("useEffect")
+},[]);
 ```
 
 ## React.useEffect with conditions
 
 ```javascript
 React.useEffect(() => {
-  ref.current = 'some value'
+    const elementById = document.querySelector('myElementId');
+    console.log('Element by ID:', elementById);
 },[])
 ```
 
 ```javascript
 React.useLayoutEffect(() => {
-  ref.current = 'some value'
+    const elementById = document.querySelector('myElementId');
+    console.log('Element by ID:', elementById);
 },[])
 ```
 
@@ -84,13 +95,15 @@ React.useLayoutEffect(() => {
 
 ```javascript
 useEffect(() => {
-  ref.current = 'some value'
+    const elementById = document.getElementById('myElementId');
+    console.log('Element by ID:', elementById);
 })
 ```
 
 ```javascript
 useLayoutEffect(() => {
-  ref.current = 'some value'
+    const elementById = document.getElementById('myElementId');
+    console.log('Element by ID:', elementById);
 })
 ```
 
@@ -98,12 +111,14 @@ useLayoutEffect(() => {
 
 ```javascript
 React.useEffect(() => {
-  ref.current = 'some value'
+    const elementById = document.getElementsByClassName('myElementId');
+    console.log('Element by ID:', elementById);
 })
 ```
 
 ```javascript
 React.useLayoutEffect(() => {
-  ref.current = 'some value'
+    const elementById = document.getElementsByClassName('myElementId');
+    console.log('Element by ID:', elementById);
 })
 ```

--- a/.grit/patterns/js/intelligent_useEffect_to_useLayoutEffect.md
+++ b/.grit/patterns/js/intelligent_useEffect_to_useLayoutEffect.md
@@ -10,16 +10,9 @@ tags: #fix
 engine marzano(0.1)
 language js
 
-
-or {
- `useEffect($body)` as $effectHook where {
-    $body <: contains `document.$method`,
-    $effectHook => `useLayoutEffect($body)`
-  },
- `React.useEffect($body)` as $effectHook where {
-  $body <: contains `document.$method`,
-  $effectHook => `React.useLayoutEffect($body)`
- }
+or {`React.$effectHook($body)`,`$effectHook($body)` } where {
+     $effectHook <: `useEffect` => `useLayoutEffect`,
+    $body <: contains `document.$method`
 }
 ```
 
@@ -27,98 +20,98 @@ or {
 
 ```javascript
 useEffect(() => {
-    // DOM Query Methods:
-    // 1. getElementById
-    const elementById = document.getElementById('myElementId');
-    console.log('Element by ID:', elementById);
-   
-    // 2. getElementsByClassName
-    const elementsByClass = document.getElementsByClassName('myClass');
-    console.log('Elements by Class:', elementsByClass);
+  // DOM Query Methods:
+  // 1. getElementById
+  const elementById = document.getElementById('myElementId');
+  console.log('Element by ID:', elementById);
 
-    // 3. querySelector
-    const elementBySelector = document.querySelector('.mySelector');
-    console.log('Element by Selector:', elementBySelector);
-}, []); 
+  // 2. getElementsByClassName
+  const elementsByClass = document.getElementsByClassName('myClass');
+  console.log('Elements by Class:', elementsByClass);
 
-useEffect(() => {
-    ref.current = 'some value'
-},[])
+  // 3. querySelector
+  const elementBySelector = document.querySelector('.mySelector');
+  console.log('Element by Selector:', elementBySelector);
+}, []);
 
 useEffect(() => {
-    console.log("useEffect")
-},[]);
+  ref.current = 'some value';
+}, []);
+
+useEffect(() => {
+  console.log('useEffect');
+}, []);
 ```
 
 ```javascript
 useLayoutEffect(() => {
-    // DOM Query Methods:
-    // 1. getElementById
-    const elementById = document.getElementById('myElementId');
-    console.log('Element by ID:', elementById);
-   
-    // 2. getElementsByClassName
-    const elementsByClass = document.getElementsByClassName('myClass');
-    console.log('Elements by Class:', elementsByClass);
+  // DOM Query Methods:
+  // 1. getElementById
+  const elementById = document.getElementById('myElementId');
+  console.log('Element by ID:', elementById);
 
-    // 3. querySelector
-    const elementBySelector = document.querySelector('.mySelector');
-    console.log('Element by Selector:', elementBySelector);
-}, []); 
+  // 2. getElementsByClassName
+  const elementsByClass = document.getElementsByClassName('myClass');
+  console.log('Elements by Class:', elementsByClass);
 
-useEffect(() => {
-    ref.current = 'some value'
-},[])
+  // 3. querySelector
+  const elementBySelector = document.querySelector('.mySelector');
+  console.log('Element by Selector:', elementBySelector);
+}, []);
 
 useEffect(() => {
-    console.log("useEffect")
-},[]);
+  ref.current = 'some value';
+}, []);
+
+useEffect(() => {
+  console.log('useEffect');
+}, []);
 ```
 
 ## React.useEffect with conditions
 
 ```javascript
 React.useEffect(() => {
-    const elementById = document.querySelector('myElementId');
-    console.log('Element by ID:', elementById);
-},[])
+  const elementById = document.querySelector('myElementId');
+  console.log('Element by ID:', elementById);
+}, []);
 ```
 
 ```javascript
 React.useLayoutEffect(() => {
-    const elementById = document.querySelector('myElementId');
-    console.log('Element by ID:', elementById);
-},[])
+  const elementById = document.querySelector('myElementId');
+  console.log('Element by ID:', elementById);
+}, []);
 ```
 
 ## useEffect without conditions
 
 ```javascript
 useEffect(() => {
-    const elementById = document.getElementById('myElementId');
-    console.log('Element by ID:', elementById);
-})
+  const elementById = document.getElementById('myElementId');
+  console.log('Element by ID:', elementById);
+});
 ```
 
 ```javascript
 useLayoutEffect(() => {
-    const elementById = document.getElementById('myElementId');
-    console.log('Element by ID:', elementById);
-})
+  const elementById = document.getElementById('myElementId');
+  console.log('Element by ID:', elementById);
+});
 ```
 
 ## React.useEffect without conditions
 
 ```javascript
 React.useEffect(() => {
-    const elementById = document.getElementsByClassName('myElementId');
-    console.log('Element by ID:', elementById);
-})
+  const elementById = document.getElementsByClassName('myElementId');
+  console.log('Element by ID:', elementById);
+});
 ```
 
 ```javascript
 React.useLayoutEffect(() => {
-    const elementById = document.getElementsByClassName('myElementId');
-    console.log('Element by ID:', elementById);
-})
+  const elementById = document.getElementsByClassName('myElementId');
+  console.log('Element by ID:', elementById);
+});
 ```


### PR DESCRIPTION
This PR contains the initial `POC` for the bellow problem:
https://github.com/getgrit/js/issues/37

Till now, I have figured out that this kind for switch it mostly required when, we are dealing with `ref.current` (If you need to mutate the `DOM` and/or do need to perform measurements)

Grit studio link: https://app.grit.io/studio?key=PvRpvvDRMSQxmDd72DIWE

Hi @morgante, this is open for suggestion, which can help to improve and make it better.