### PR TITLE
Keep if statement from React constructor componen

### DIFF
--- a/.grit/patterns/js/react_hooks.grit
+++ b/.grit/patterns/js/react_hooks.grit
@@ -46,12 +46,12 @@ private pattern handle_one_statement($class_name, $statements, $states_statement
                     $name <: js"constructor",
                     $body <: contains `super($_)` => .,
                     $body <: contains `this.$_ = $_.bind(this)` => .,
-                    $body <: maybe contains bubble($constructor_statements) {
-                        statement_block($statements) where {                            
+                    $body <: maybe bubble($constructor_statements) {
+                        statement_block($statements) where {
                             $statements <: some bubble($constructor_statements) $statement where {                                
-                                $constructor_statements += $statement
+                                $constructor_statements += $statement 
                             }
-                        }                    
+                        }
                     },
                     $body <: change_this($states_statements, is_constructor=true),
                 },

--- a/.grit/patterns/js/react_hooks.grit
+++ b/.grit/patterns/js/react_hooks.grit
@@ -46,6 +46,9 @@ private pattern handle_one_statement($class_name, $statements, $states_statement
                     $name <: js"constructor",
                     $body <: maybe contains bubble($constructor_statements) {
                         or {
+                            if_statement($condition, $consequence) as $exp where {
+                                $constructor_statements += $exp
+                            },
                             lexical_declaration($declarations) as $decl where $declarations <:
                                 variable_declarator($name, $value) where {
                                     $name <: not contains js"this.state",
@@ -55,6 +58,7 @@ private pattern handle_one_statement($class_name, $statements, $states_statement
                             expression_statement() as $decl where {
                                 $decl <: not contains `super($props)`,
                                 $decl <: not contains `$_.bind($_)`,
+                                $decl <: not within if_statement(),
                                 $constructor_statements += $decl,
                             },
                         }

--- a/.grit/patterns/js/react_hooks.grit
+++ b/.grit/patterns/js/react_hooks.grit
@@ -49,13 +49,9 @@ private pattern handle_one_statement($class_name, $statements, $states_statement
                         `this.$_ = $_.bind(this)` => .,
                         `this.state = $_` => .,
                     },
-                    $body <: maybe bubble($constructor_statements) {
-                        statement_block($statements) where {
-                            $statements <: some bubble($constructor_statements) $statement where {
-                                $constructor_statements += $statement
-                            }
-                        }
-                    },
+                    $body <: statement_block($statements=some bubble($constructor_statements) $statement where {
+                        $constructor_statements += $statement
+                    }),
                     $body <: change_this($states_statements, is_constructor=true),
                 },
                 and {

--- a/.grit/patterns/js/react_hooks.grit
+++ b/.grit/patterns/js/react_hooks.grit
@@ -44,14 +44,14 @@ private pattern handle_one_statement($class_name, $statements, $states_statement
             or {
                 and {
                     $name <: js"constructor",
-                    $body <: maybe contains bubble($constructor_statements) {
+                    $body <: contains or {
+                        `super($_)` => .,
+                        `this.$_ = $_.bind(this)` => .,
+                        `this.state = $_` => .,
+                    },
+                    $body <: maybe bubble($constructor_statements) {
                         statement_block($statements) where {
                             $statements <: some bubble($constructor_statements) $statement where {
-                                $constructor_statements <: not contains $statement,
-                                $statement <: not contains or {
-                                    `super($_)`,
-                                    `this.$_ = $_.bind(this)`,
-                                },
                                 $constructor_statements += $statement
                             }
                         }

--- a/.grit/patterns/js/react_hooks.grit
+++ b/.grit/patterns/js/react_hooks.grit
@@ -44,12 +44,12 @@ private pattern handle_one_statement($class_name, $statements, $states_statement
             or {
                 and {
                     $name <: js"constructor",
-                    $body <: contains or {
-                        `super($_)` => .,
-                        `this.$_ = $_.bind(this)` => .,
-                        `this.state = $_` => .,
-                    },
-                    $body <: maybe bubble($constructor_statements) {
+                    $body <: maybe contains or {
+                        `super($_)`,
+                        `this.$_ = $_.bind(this)`,
+                        `this.state = $_`,
+                    } => .,
+                    $body <: bubble($constructor_statements) {
                         statement_block($statements) where {
                             $statements <: some bubble($constructor_statements) $stm where {
                                 $constructor_statements += $stm

--- a/.grit/patterns/js/react_hooks.grit
+++ b/.grit/patterns/js/react_hooks.grit
@@ -44,13 +44,14 @@ private pattern handle_one_statement($class_name, $statements, $states_statement
             or {
                 and {
                     $name <: js"constructor",
+                    $body <: contains `super($_)` => .,
+                    $body <: contains `this.$_ = $_.bind(this)` => .,
                     $body <: maybe contains bubble($constructor_statements) {
-                        statement_block() as $block where and {
-                            $block <: not contains `super(props)`,
-                            $block <: not contains `$_.bind($_)`,
-                            $block <: not contains `this.state = $_`,
-                            $constructor_statements += `$block`
-                        }
+                        statement_block($statements) where {                            
+                            $statements <: some bubble($constructor_statements) $statement where {                                
+                                $constructor_statements += $statement
+                            }
+                        }                    
                     },
                     $body <: change_this($states_statements, is_constructor=true),
                 },

--- a/.grit/patterns/js/react_hooks.grit
+++ b/.grit/patterns/js/react_hooks.grit
@@ -49,9 +49,13 @@ private pattern handle_one_statement($class_name, $statements, $states_statement
                         `this.$_ = $_.bind(this)` => .,
                         `this.state = $_` => .,
                     },
-                    $body <: statement_block($statements=some bubble($constructor_statements) $statement where {
-                        $constructor_statements += $statement
-                    }),
+                    $body <: maybe bubble($constructor_statements) {
+                        statement_block($statements) where {
+                            $statements <: some bubble($constructor_statements) $stm where {
+                                $constructor_statements += $stm
+                            }
+                        }
+                    },
                     $body <: change_this($states_statements, is_constructor=true),
                 },
                 and {

--- a/.grit/patterns/js/react_hooks.grit
+++ b/.grit/patterns/js/react_hooks.grit
@@ -44,12 +44,15 @@ private pattern handle_one_statement($class_name, $statements, $states_statement
             or {
                 and {
                     $name <: js"constructor",
-                    $body <: contains `super($_)` => .,
-                    $body <: contains `this.$_ = $_.bind(this)` => .,
-                    $body <: maybe bubble($constructor_statements) {
+                    $body <: maybe contains bubble($constructor_statements) {
                         statement_block($statements) where {
-                            $statements <: some bubble($constructor_statements) $statement where {                                
-                                $constructor_statements += $statement 
+                            $statements <: some bubble($constructor_statements) $statement where {
+                                $constructor_statements <: not contains $statement,
+                                $statement <: not contains or {
+                                    `super($_)`,
+                                    `this.$_ = $_.bind(this)`,
+                                },
+                                $constructor_statements += $statement
                             }
                         }
                     },

--- a/.grit/patterns/js/react_hooks.grit
+++ b/.grit/patterns/js/react_hooks.grit
@@ -45,22 +45,11 @@ private pattern handle_one_statement($class_name, $statements, $states_statement
                 and {
                     $name <: js"constructor",
                     $body <: maybe contains bubble($constructor_statements) {
-                        or {
-                            if_statement($condition, $consequence) as $exp where {
-                                $constructor_statements += $exp
-                            },
-                            lexical_declaration($declarations) as $decl where $declarations <:
-                                variable_declarator($name, $value) where {
-                                    $name <: not contains js"this.state",
-                                    $value <: not contains js"this.state",
-                                    $constructor_statements += $decl
-                                },
-                            expression_statement() as $decl where {
-                                $decl <: not contains `super($props)`,
-                                $decl <: not contains `$_.bind($_)`,
-                                $decl <: not within if_statement(),
-                                $constructor_statements += $decl,
-                            },
+                        statement_block() as $block where and {
+                            $block <: not contains `super(props)`,
+                            $block <: not contains `$_.bind($_)`,
+                            $block <: not contains `this.state = $_`,
+                            $constructor_statements += `$block`
                         }
                     },
                     $body <: change_this($states_statements, is_constructor=true),

--- a/.grit/patterns/js/react_to_hooks.md
+++ b/.grit/patterns/js/react_to_hooks.md
@@ -683,7 +683,12 @@ import { Component } from 'react';
 
 class MyComponent extends Component {
   constructor(props: Props) {
+    super(props);
     const five = 2 + 3;
+
+    this.doSomething = this.doSomething.bind(this)
+    this.saySomething = this.saySomething.bind(this)
+
     this.saySomething();
 
     if(five === 5){

--- a/.grit/patterns/js/react_to_hooks.md
+++ b/.grit/patterns/js/react_to_hooks.md
@@ -685,6 +685,12 @@ class MyComponent extends Component {
   constructor(props: Props) {
     const five = 2 + 3;
     this.saySomething();
+
+    if(five === 5){
+      console.log("Hello");
+      this.doSomething();
+    }
+
     this.state = {
       secret: five,
     };
@@ -692,6 +698,10 @@ class MyComponent extends Component {
 
   saySomething() {
     console.log('hi');
+  }
+
+  doSomething(){
+    console.log("Welcome")
   }
 
   render() {
@@ -709,10 +719,17 @@ const MyComponent = () => {
   const saySomethingHandler = useCallback(() => {
     console.log('hi');
   }, []);
-
+  const doSomethingHandler = useCallback(() => {
+    console.log("Welcome");
+  }, []);
+  
   const five = 2 + 3;
-  saySomethingHandler();
-
+  saySomethingHandler(); 
+  if (five === 5) {
+    console.log("Hello")
+    doSomethingHandler()
+  }
+  
   return <></>;
 };
 ```

--- a/.grit/patterns/js/react_to_hooks.md
+++ b/.grit/patterns/js/react_to_hooks.md
@@ -1296,3 +1296,32 @@ const ThisBind = () => {
 
 export default ThisBind;
 ```
+
+
+## Keep the constructor logic even if there is not super(props)
+
+```ts
+import { Component } from 'base';
+
+export default class ThisBind extends Component {
+  constructor(){
+    console.log("Hello?")
+  }
+
+  render() {
+    return null;
+  }
+}
+```
+
+```ts
+import { Component } from "base";
+
+const ThisBind = () => {
+  console.log("Hello?");
+
+  return null;
+};
+
+export default ThisBind;
+```

--- a/.grit/patterns/js/react_to_hooks.md
+++ b/.grit/patterns/js/react_to_hooks.md
@@ -729,6 +729,7 @@ const MyComponent = () => {
   }, []);
   
   const five = 2 + 3;
+
   saySomethingHandler(); 
   if (five === 5) {
     console.log("Hello")


### PR DESCRIPTION
The changes fix the issue from [this PR](https://github.com/preset-io/superset/pull/700/files?diff=split&w=0#r1435420096) where migrations remove the if statement from the React component constructor logs.