### PR TITLE
Feat/componentDidMount with prevProps

### DIFF
--- a/.grit/patterns/js/react_hooks.grit
+++ b/.grit/patterns/js/react_hooks.grit
@@ -227,11 +227,13 @@ private pattern handle_one_statement($class_name, $statements, $states_statement
         },
     }
 }
+
 private pattern prepend_comment($statements) {
     maybe after comment() as $comment where {
         $statements += js"$comment"
     }
 }
+
 private pattern change_this($states_statements, $is_constructor) {
     maybe contains bubble($states_statements, $is_constructor) or {
         assignment_expression(
@@ -273,7 +275,6 @@ private pattern find_miscellaneous_state($states_statements) {
         $states_statements += `const [$name, set$capitalized] = useState();`,
     },
 }
-
 
 private pattern gather_hooks($hooks) {
     contains or {
@@ -350,6 +351,7 @@ private pattern maybe_wrapped_class_declaration($class_name, $body, $class) {
         $heritage <: contains extends_clause(value = contains or { `Component`, `PureComponent` })
     }
 }
+
 pattern first_step($use_ref_from, $handler_callback_suffix) {
     maybe_wrapped_class_declaration($class_name, $body, $class) where {
         $statements = [],
@@ -357,6 +359,7 @@ pattern first_step($use_ref_from, $handler_callback_suffix) {
         $constructor_statements = [],
         $states_statements = [],
         $static_statements = [],
+
         if ($body <: contains js"$class_name.$name = $_" ) {
             $static_statements += raw`/*\n* TODO: Class component's static variables are reassigned, needs manual handling\n*/`,
         },
@@ -425,23 +428,25 @@ pattern first_step($use_ref_from, $handler_callback_suffix) {
             $type_annotation = .
         },
 
-        if ($body <: contains `props`) {
+        if (or { $body <: contains `props`, $use_previous_value_hook <: true }) {
             $args = `$[the_props]$[type_annotation]`
-        } else {
+        } else  {
             $args = .
         },
+
         if ($use_previous_value_hook <: true) {
             $previous_value_hook = `\nfunction usePreviousValue(){\n    const ref = useRef();\n    useEffect(() => {\n        ref.current = props;\n    });\n    return ref.current;\n}\n`,
         } else {
             $previous_value_hook = .
         },
-  
+
         $separator = `\n    `,
         $states_statements = distinct(list=$states_statements),
         $states_statements = join(list = $states_statements, $separator),
         $statements = join(list = $statements, $separator),
         $constructor_statements = join(list = $constructor_statements, $separator),
         $the_function = `($args) => {\n    $states_statements\n\n    $statements\n\n    $constructor_statements\n\n    $render_statements \n}`,
+        
         // Construct the final class name
         $original_name = $class_name,
         if ($body <: contains r"(v|V)iewState"($_)) {

--- a/.grit/patterns/js/react_hooks.grit
+++ b/.grit/patterns/js/react_hooks.grit
@@ -38,7 +38,7 @@ private pattern handle_ref($statements, $statement, $name, $type) {
   }
 }
 
-private pattern handle_one_statement($class_name, $statements, $states_statements, $static_statements, $render_statements, $constructor_statements, $handler_callback_suffix, $use_ref_from) {
+private pattern handle_one_statement($class_name, $statements, $states_statements, $static_statements, $render_statements, $constructor_statements, $handler_callback_suffix, $use_ref_from, $use_previous_value_hook) {
     or {
         method_definition($static, $async, $name, $body, $parameters) as $statement where {
             or {
@@ -62,6 +62,11 @@ private pattern handle_one_statement($class_name, $statements, $states_statement
                     $statement <: prepend_comment($statements),
                     $name <: or { `componentDidUpdate`, `componentDidMount` },
                     $body <: change_this($states_statements, is_constructor=false),
+                    $parameters <: maybe contains required_parameter(pattern=$prevProps) where {
+                        $body <: contains $prevProps,
+                        $use_previous_value_hook = true,
+                        $states_statements += `const $prevProps = usePreviousValue(props);`,
+                    },
                     or {
                         {
                             $async <: `async`,
@@ -348,6 +353,7 @@ private pattern maybe_wrapped_class_declaration($class_name, $body, $class) {
 pattern first_step($use_ref_from, $handler_callback_suffix) {
     maybe_wrapped_class_declaration($class_name, $body, $class) where {
         $statements = [],
+        $use_previous_value_hook = false,
         $constructor_statements = [],
         $states_statements = [],
         $static_statements = [],
@@ -373,7 +379,7 @@ pattern first_step($use_ref_from, $handler_callback_suffix) {
 
         // Set an alternative callback suffix, or remove it entirely
 
-        $body <: contains handle_one_statement($class_name, $statements, $states_statements, $static_statements, $render_statements, $constructor_statements, $handler_callback_suffix, $use_ref_from) until `defaultProps = { $_ }`,
+        $body <: contains handle_one_statement($class_name, $statements, $states_statements, $static_statements, $render_statements, $constructor_statements, $handler_callback_suffix, $use_ref_from, $use_previous_value_hook) until `defaultProps = { $_ }`,
         $program <: maybe contains interface_declaration(body=$interface, name=$interface_name) where {
             $state_type <: $interface_name,
             $interface <: contains bubble($states_statements, $body) {
@@ -424,14 +430,18 @@ pattern first_step($use_ref_from, $handler_callback_suffix) {
         } else {
             $args = .
         },
-
+        if ($use_previous_value_hook <: true) {
+            $previous_value_hook = `\nfunction usePreviousValue(){\n    const ref = useRef();\n    useEffect(() => {\n        ref.current = props;\n    });\n    return ref.current;\n}\n`,
+        } else {
+            $previous_value_hook = .
+        },
+  
         $separator = `\n    `,
         $states_statements = distinct(list=$states_statements),
         $states_statements = join(list = $states_statements, $separator),
         $statements = join(list = $statements, $separator),
         $constructor_statements = join(list = $constructor_statements, $separator),
         $the_function = `($args) => {\n    $states_statements\n\n    $statements\n\n    $constructor_statements\n\n    $render_statements \n}`,
-
         // Construct the final class name
         $original_name = $class_name,
         if ($body <: contains r"(v|V)iewState"($_)) {
@@ -444,7 +454,7 @@ export const $original_name = observer($base_name);`,
         },
 
         $static_statements = join(list = $static_statements, $separator),
-        $class => `$the_const\n\n$static_statements\n`
+        $class => `$the_const\n\n$static_statements\n $previous_value_hook`,
     }
 }
 

--- a/.grit/patterns/js/react_hooks.grit
+++ b/.grit/patterns/js/react_hooks.grit
@@ -446,7 +446,7 @@ pattern first_step($use_ref_from, $handler_callback_suffix) {
         $statements = join(list = $statements, $separator),
         $constructor_statements = join(list = $constructor_statements, $separator),
         $the_function = `($args) => {\n    $states_statements\n\n    $statements\n\n    $constructor_statements\n\n    $render_statements \n}`,
-        
+
         // Construct the final class name
         $original_name = $class_name,
         if ($body <: contains r"(v|V)iewState"($_)) {
@@ -575,6 +575,11 @@ private pattern gather_accesses($hoisted_states, $hoisted_refs, $use_memos) {
             and {
                 $name <: array_pattern(elements = [$used_name, $_]),
                 $value <: `useState($_)`,
+                $hoisted_states += $name
+            },
+            and {
+                $name <: $used_name,
+                $value <: `usePreviousValue($_)`,
                 $hoisted_states += $name
             },
             and {

--- a/.grit/patterns/js/react_to_hooks.md
+++ b/.grit/patterns/js/react_to_hooks.md
@@ -95,12 +95,13 @@ class App extends Component {
 ```
 
 ```ts
-import { useState, useEffect, useCallback } from 'react';
-const App = () => {
+import { useState, useEffect, useCallback, useRef } from 'react';
+const App = (props) => {
   const [name, setName] = useState('');
   const [another, setAnother] = useState(3);
   const [count, setCount] = useState();
   const [isOpen, setIsOpen] = useState();
+  const prevProps = usePreviousValue(props);  
 
   useEffect(() => {
     document.title = `You clicked ${count} times`;
@@ -112,7 +113,7 @@ const App = () => {
     if (isOpen && !prevProps.isOpen) {
       alert('You just opened the modal!');
     }
-  }, [count, isOpen]);
+  }, [count, isOpen, prevProps]);
   const alertNameHandler = useCallback(() => {
     alert(name);
   }, [name]);
@@ -142,6 +143,14 @@ App.bar = (input) => {
 App.another = (input) => {
   console.error(input);
 };
+
+function usePreviousValue() {
+  const ref = useRef();
+  useEffect(() => {
+    ref.current = props;
+  });
+  return ref.current;
+}
 ```
 
 ## MobX - Observables and Computed


### PR DESCRIPTION
- [x] Add a custom `usePreviousValue` hook next to the component when the `componentDidMount`uses `prevProps` parameters. 
- [x] Add `usePreviousValue` hook only if needed
- [x] Add `usePreviousValue(props)` to component body
- [x] Add `prevProps` to the `useEffect` dependencies
- [x] Add a props parameter to component