### PR TITLE
feat: react query 3 to react query 4 migration

### DIFF
--- a/.grit/patterns/js/migrating_from_react_query_3_to_react_query_4.md
+++ b/.grit/patterns/js/migrating_from_react_query_3_to_react_query_4.md
@@ -30,7 +30,7 @@ or {
 }
 ```
 
-## React query 3 --> React query 4
+## TanStack query 3 --> React query 4
 
 ```javascript
 import { useQuery } from 'react-query'

--- a/.grit/patterns/js/migrating_from_react_query_3_to_react_query_4.md
+++ b/.grit/patterns/js/migrating_from_react_query_3_to_react_query_4.md
@@ -1,18 +1,18 @@
 ---
-title: Migrate from React query 3 to React query 4
+title: Migrate from TanStack Query 3 to React query 4
 ---
 
-We have now new version for react query v4, v5
+This pattern migrates from React Query v3 to React Query v4. It is the equivalent of the [codemod](https://github.com/TanStack/query/tree/8e7c34f448923694fdeac43fbaac83579b74f485/packages/codemods/src/v4).
 
 tags: #react, #migration, #reactquery
 
 ```grit
 engine marzano(0.1)
-language js
+language js(jsx)
 
 or {
     `"react-query"` => `"@tanstack/react-query"`,
-    `"react-query/devtools"` => `'@tanstack/react-query-devtools'`,
+    `"react-query/devtools"` => `"@tanstack/react-query-devtools"`,
     `useQuery($params1, $param2)` => `useQuery([$params1], $param2)`, // need more improvement
     `useQueries([$param])` => `useQueries({queries: [$param]})`,
     `"react-query/persistQueryClient-experimental"` => `"@tanstack/react-query-persist-client"`,
@@ -33,7 +33,7 @@ import { ReactQueryDevtools } from 'react-query/devtools'
 import { persistQueryClient } from 'react-query/persistQueryClient-experimental'
 import { createWebStoragePersistor } from 'react-query/createWebStoragePersistor-experimental'
 import { createAsyncStoragePersistor } from 'react-query/createAsyncStoragePersistor-experimental'
-import { QueryClient, setLogger } from 'react-query';
+import { QueryClient, setLogger } from 'react-query'
 import { dehydrate, hydrate, useHydrate, Hydrate } from 'react-query/hydration'
 import { QueryClientProvider } from 'react-query/react';
 
@@ -47,19 +47,19 @@ useQueries([{ queryKey1, queryFn1, options1 }, { queryKey2, queryFn2, options2 }
 ```
 
 ```javascript
-import { useQuery } from '@tanstack/react-query'
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
-import { persistQueryClient } from '@tanstack/react-query-persist-client'
-import { createSyncStoragePersister } from '@tanstack/query-sync-storage-persister'
-import { createAsyncStoragePersister } from '@tanstack/query-async-storage-persister'
-import { QueryClient, setLogger } from '@tanstack/react-query';
-import { dehydrate, hydrate, useHydrate, Hydrate } from '@tanstack/react-query'
-import { QueryClientProvider } from '@tanstack/react-query/reactjs';
+import { useQuery } from "@tanstack/react-query"
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools"
+import { persistQueryClient } from "@tanstack/react-query-persist-client"
+import { createWebStoragePersistor } from "@tanstack/query-sync-storage-persister"
+import { createAsyncStoragePersistor } from "@tanstack/query-async-storage-persister"
+import { QueryClient, setLogger } from "@tanstack/react-query"
+import { dehydrate, hydrate, useHydrate, Hydrate } from "@tanstack/react-query"
+import { QueryClientProvider } from "@tanstack/react-query/reactjs";
 
 
-const queryClient = new QueryClient({ logger: customLogger })
+const queryClient = new QueryClient({ logger: customLogger});
 
 
 useQuery(['todos'], fetchTodos)
-useQueries({ queries: [{ queryKey1, queryFn1, options1 }, { queryKey2, queryFn2, options2 }] })
+useQueries({queries: [{ queryKey1, queryFn1, options1 }, { queryKey2, queryFn2, options2 }]})
 ```

--- a/.grit/patterns/js/migrating_from_react_query_3_to_react_query_4.md
+++ b/.grit/patterns/js/migrating_from_react_query_3_to_react_query_4.md
@@ -8,18 +8,23 @@ tags: #react, #migration, #reactquery
 
 ```grit
 engine marzano(0.1)
-language js(jsx)
+language js
 
 or {
     `"react-query"` => `"@tanstack/react-query"`,
     `"react-query/devtools"` => `"@tanstack/react-query-devtools"`,
-    `useQuery($params1, $param2)` => `useQuery([$params1], $param2)`, // need more improvement
+    `useQuery($params)` where {
+        $params <: contains `'$param'` => `['$param']`
+    },
     `useQueries([$param])` => `useQueries({queries: [$param]})`,
     `"react-query/persistQueryClient-experimental"` => `"@tanstack/react-query-persist-client"`,
     `"react-query/createWebStoragePersistor-experimental"` => `"@tanstack/query-sync-storage-persister"`,
     `"react-query/createAsyncStoragePersistor-experimental"` => `"@tanstack/query-async-storage-persister"`,
     `setLogger($customLogger)` => ``,
-    `new QueryClient()` => `new QueryClient({ logger: customLogger})`, // need more improvement
+    `` as $queryClient where {
+        $queryClient <: contains `setLogger($customLogger)`,
+        $queryClient <: contains `new QueryClient()` => `new QueryClient({logger: $customLogger});`
+    },
     `"react-query/hydration"` => `"@tanstack/react-query"`,
     `"react-query/react"` => `"@tanstack/react-query/reactjs"`,
 }
@@ -43,6 +48,7 @@ const queryClient = new QueryClient();
 
 
 useQuery('todos', fetchTodos)
+useQuery('todos', fetchTodos, cacheParams)
 useQueries([{ queryKey1, queryFn1, options1 }, { queryKey2, queryFn2, options2 }])
 ```
 
@@ -57,9 +63,10 @@ import { dehydrate, hydrate, useHydrate, Hydrate } from "@tanstack/react-query"
 import { QueryClientProvider } from "@tanstack/react-query/reactjs";
 
 
-const queryClient = new QueryClient({ logger: customLogger});
+const queryClient = new QueryClient({logger: customLogger});
 
 
 useQuery(['todos'], fetchTodos)
+useQuery(['todos'], fetchTodos, cacheParams)
 useQueries({queries: [{ queryKey1, queryFn1, options1 }, { queryKey2, queryFn2, options2 }]})
 ```

--- a/.grit/patterns/js/migrating_from_react_query_3_to_react_query_4.md
+++ b/.grit/patterns/js/migrating_from_react_query_3_to_react_query_4.md
@@ -1,0 +1,65 @@
+---
+title: Migrate from React query 3 to React query 4
+---
+
+We have now new version for react query v4, v5
+
+tags: #react, #migration, #reactquery
+
+```grit
+engine marzano(0.1)
+language js
+
+or {
+    `"react-query"` => `"@tanstack/react-query"`,
+    `"react-query/devtools"` => `'@tanstack/react-query-devtools'`,
+    `useQuery($params1, $param2)` => `useQuery([$params1], $param2)`, // need more improvement
+    `useQueries([$param])` => `useQueries({queries: [$param]})`,
+    `"react-query/persistQueryClient-experimental"` => `"@tanstack/react-query-persist-client"`,
+    `"react-query/createWebStoragePersistor-experimental"` => `"@tanstack/query-sync-storage-persister"`,
+    `"react-query/createAsyncStoragePersistor-experimental"` => `"@tanstack/query-async-storage-persister"`,
+    `setLogger($customLogger)` => ``,
+    `new QueryClient()` => `new QueryClient({ logger: customLogger})`, // need more improvement
+    `"react-query/hydration"` => `"@tanstack/react-query"`,
+    `"react-query/react"` => `"@tanstack/react-query/reactjs"`,
+}
+```
+
+## React query 3 --> React query 4
+
+```javascript
+import { useQuery } from 'react-query'
+import { ReactQueryDevtools } from 'react-query/devtools'
+import { persistQueryClient } from 'react-query/persistQueryClient-experimental'
+import { createWebStoragePersistor } from 'react-query/createWebStoragePersistor-experimental'
+import { createAsyncStoragePersistor } from 'react-query/createAsyncStoragePersistor-experimental'
+import { QueryClient, setLogger } from 'react-query';
+import { dehydrate, hydrate, useHydrate, Hydrate } from 'react-query/hydration'
+import { QueryClientProvider } from 'react-query/react';
+
+
+setLogger(customLogger)
+const queryClient = new QueryClient();
+
+
+useQuery('todos', fetchTodos)
+useQueries([{ queryKey1, queryFn1, options1 }, { queryKey2, queryFn2, options2 }])
+```
+
+```javascript
+import { useQuery } from '@tanstack/react-query'
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+import { persistQueryClient } from '@tanstack/react-query-persist-client'
+import { createSyncStoragePersister } from '@tanstack/query-sync-storage-persister'
+import { createAsyncStoragePersister } from '@tanstack/query-async-storage-persister'
+import { QueryClient, setLogger } from '@tanstack/react-query';
+import { dehydrate, hydrate, useHydrate, Hydrate } from '@tanstack/react-query'
+import { QueryClientProvider } from '@tanstack/react-query/reactjs';
+
+
+const queryClient = new QueryClient({ logger: customLogger })
+
+
+useQuery(['todos'], fetchTodos)
+useQueries({ queries: [{ queryKey1, queryFn1, options1 }, { queryKey2, queryFn2, options2 }] })
+```


### PR DESCRIPTION
The pattern will help to migrate from `React Query 3` to `React Query 3`

Reference: https://tanstack.com/query/v4/docs/react/guides/migrating-to-react-query-4
Grit studio link: https://app.grit.io/studio?key=0Xzm-CsbLBPNVTPtNWkwe