### PR TITLE
feat: find useless ternary operator

### DIFF
--- a/.grit/patterns/js/useless-ternary-operator.md
+++ b/.grit/patterns/js/useless-ternary-operator.md
@@ -1,0 +1,30 @@
+---
+title: Find useless ternary operator
+---
+
+If $condition ? `$answer`:`$answer` then this expression returns $answer. This is probably a human error
+
+tags: #fix
+
+```grit
+engine marzano(0.1)
+language js
+
+js"$condition ? `$answer` : `$answer`" => js"$condition ? `$answer` : `$answer` //useless-ternary operator both result are sanme"
+```
+
+## `<></>` ⇒ `React.Fragment`
+
+```javascript
+data === "value" ? `/r/${data.id}` : `/r/${data.id}`
+
+
+data === "value" ? `/r/${data.id}` : `/r/${data.name}`
+```
+
+```javascript
+data === "value" ? `/r/${data.id}` : `/r/${data.id}` //useless-ternary operator both result are sanme
+
+
+data === "value" ? `/r/${data.id}` : `/r/${data.name}`
+```


### PR DESCRIPTION
If `$condition` ? `$answer`:`$answer` then this expression returns $answer. `This is probably a human error`

Grit studio link: https://app.grit.io/studio?key=vdLSOjh9zNgvkekW4_n2a