### PR TITLE
feat: move defined styled components outside component module level

### DIFF
--- a/.grit/patterns/js/move-defined-styled-components-outside-module-level.md
+++ b/.grit/patterns/js/move-defined-styled-components-outside-module-level.md
@@ -1,5 +1,5 @@
 ---
-title: Warning for defined styled components on module level
+title: Move defined styled components outside component module level.
 ---
 
 Creating a styled component inside the render method in React leads to performance issues because it dynamically generates a new component in the DOM on each render. This causes React to discard and recalculate that part of the DOM subtree every time, rather than efficiently updating only the changed parts. This can result in performance bottlenecks and unpredictable behaviour.
@@ -13,13 +13,17 @@ engine marzano(0.1)
 language js
 
 or {
-    react_functional_component($props, $body),
-    react_class_component($props, $body)
+    react_functional_component($props, $body) as $comp,
+    react_class_component($props, $body) as $comp
 } where {
-    or {
-        $body <: contains js"styled($component)`$style`" as $styledComponent => `$styledComponent // warnig: styled components should be always outside react component`,
-        $body <: contains js"styled.$tag`$style`" as $styledComponent => `$styledComponent // warnig: styled components should be always outside react component`,
-    }
+     $body <: contains or {
+        js"const $componentName = styled($component)`$style`",
+        js"const $componentName = styled.$tag`$style`"
+    } as $styledComponent,
+    $copy = text($styledComponent),
+    $styledComponent => .,
+    $body <: contains `return <$componentName />` => ``,
+    $comp => `$copy\n\n$comp`,
 }
 ```
 
@@ -80,35 +84,43 @@ const Component2 = styled(Component)`
   color: blue;
 `
 
-function FunctionalComponent() {
-  const Component3 = styled.div`
+const Component3 = styled.div`
     color: blue;
-  ` // warnig: styled components should be always outside react component
-  return <Component3 />
+  `
+
+function FunctionalComponent() {
+  
+  
 }
 
-function FunctionalComponent2() {
-  const Component3 = styled(FunctionalComponent)`
+const Component3 = styled(FunctionalComponent)`
     color: blue;
-  ` // warnig: styled components should be always outside react component
-  return <Component3 />
+  `
+
+function FunctionalComponent2() {
+  
+  
 }
+
+const Component4 = styled.div`
+        color: blue;
+    `
 
 class MyComponent extends Component {
   public render() {
-    const Component4 = styled.div`
-        color: blue;
-    ` // warnig: styled components should be always outside react component
-    return <Component4 />
+    
+    
   }
 }
 
+const Component4 = styled.div`
+        color: blue;
+    `
+
 class MyComponent extends Component <Compnent, {}> {
   public render() {
-    const Component4 = styled.div`
-        color: blue;
-    ` // warnig: styled components should be always outside react component
-    return <Component4 />
+    
+    
   }
 }
 ```

--- a/.grit/patterns/js/move-defined-styled-components-outside-module-level.md
+++ b/.grit/patterns/js/move-defined-styled-components-outside-module-level.md
@@ -22,7 +22,6 @@ or {
     } as $styledComponent,
     $copy = text($styledComponent),
     $styledComponent => .,
-    $body <: contains `return <$componentName />` => ``,
     $comp => `$copy\n\n$comp`,
 }
 ```
@@ -54,7 +53,7 @@ function FunctionalComponent2() {
   return <Component3 />
 }
 
-class MyComponent extends Component {
+class MyComponent {
   public render() {
     const Component4 = styled.div`
         color: blue;
@@ -90,7 +89,7 @@ const Component3 = styled.div`
 
 function FunctionalComponent() {
   
-  
+  return <Component3 />
 }
 
 const Component3 = styled(FunctionalComponent)`
@@ -99,17 +98,17 @@ const Component3 = styled(FunctionalComponent)`
 
 function FunctionalComponent2() {
   
-  
+  return <Component3 />
 }
 
 const Component4 = styled.div`
         color: blue;
     `
 
-class MyComponent extends Component {
+class MyComponent {
   public render() {
     
-    
+    return <Component4 />
   }
 }
 
@@ -120,7 +119,7 @@ const Component4 = styled.div`
 class MyComponent extends Component <Compnent, {}> {
   public render() {
     
-    
+    return <Component4 />
   }
 }
 ```

--- a/.grit/patterns/js/react.grit
+++ b/.grit/patterns/js/react.grit
@@ -18,8 +18,10 @@ pattern react_functional_component($props, $body) {
 }
 
 pattern react_class_component($props, $body) {
-    or {
-        `class $classComponent {$body}`,
-        `class $classComponent<$props> {$body}`,
-    }
+  or {
+    `class $ClassComponent {$body}`,
+    `class $ClassComponent extends $ComponentName {$body}`,
+    `class $ClassComponent<$props> {$body}`,
+    `class $ClassComponent extends $ComponentName<$props> {$body}`,
+  }
 }

--- a/.grit/patterns/js/react.grit
+++ b/.grit/patterns/js/react.grit
@@ -8,7 +8,6 @@ pattern ReactNode($name, $props, $children) {
   }
 }
 
-
 pattern react_functional_component($props, $body) {
   or {
     `const $name = ($props) => {$body}`,
@@ -16,4 +15,11 @@ pattern react_functional_component($props, $body) {
     `function $func($props) {$body}`,
     `function $func($props: $propsType): $returnType {$body}`,
   }
+}
+
+pattern react_class_component($props, $body) {
+    or {
+        `class $classComponent {$body}`,
+        `class $classComponent<$props> {$body}`,
+    }
 }

--- a/.grit/patterns/js/warning-for-defined-styled-components-on-module-level.md
+++ b/.grit/patterns/js/warning-for-defined-styled-components-on-module-level.md
@@ -1,0 +1,117 @@
+---
+title: Warning for defined styled components on module level
+---
+
+Creating a styled component inside the render method in React leads to performance issues because it dynamically generates a new component in the DOM on each render. This causes React to discard and recalculate that part of the DOM subtree every time, rather than efficiently updating only the changed parts. This can result in performance bottlenecks and unpredictable behavior.
+
+tags: #react, #migration, #styled-component
+
+```grit
+engine marzano(0.1)
+language js
+
+or {
+    react_functional_component($props, $body) where {
+        or {
+            $body <: contains js"styled($component)`$style`" as $styledComponent => `$styledComponent // warnig: styled components should be always outside react component`,
+            $body <: contains js"styled.$tag`$style`" as $styledComponent => `$styledComponent // warnig: styled components should be always outside react component`,
+        }
+    },
+    react_class_component($props, $body) where {
+        or {
+            $body <: contains js"styled($component)`$style`" as $styledComponent => `$styledComponent // warnig: styled components should be always outside react component`,
+            $body <: contains js"styled.$tag`$style`" as $styledComponent => `$styledComponent // warnig: styled components should be always outside react component`,
+        }
+    }
+}
+```
+
+## Warning for defined styled components on module level
+
+```javascript
+import styled from "styled-components";
+
+const Component = styled.div`
+  color: blue;
+`
+
+const Component2 = styled(Component)`
+  color: blue;
+`
+
+function FunctionalComponent() {
+  const Component3 = styled.div`
+    color: blue;
+  `
+  return <Component3 />
+}
+
+function FunctionalComponent2() {
+  const Component3 = styled(FunctionalComponent)`
+    color: blue;
+  `
+  return <Component3 />
+}
+
+class MyComponent extends Component {
+  public render() {
+    const Component4 = styled.div`
+        color: blue;
+    `
+    return <Component4 />
+  }
+}
+
+class MyComponent extends Component <Compnent, {}> {
+  public render() {
+    const Component4 = styled.div`
+        color: blue;
+    `
+    return <Component4 />
+  }
+}
+```
+
+```javascript
+import styled from "styled-components";
+
+const Component = styled.div`
+  color: blue;
+`
+
+const Component2 = styled(Component)`
+  color: blue;
+`
+
+function FunctionalComponent() {
+  const Component3 = styled.div`
+    color: blue;
+  ` // warnig: styled components should be always outside react component
+  return <Component3 />
+}
+
+function FunctionalComponent2() {
+  const Component3 = styled(FunctionalComponent)`
+    color: blue;
+  ` // warnig: styled components should be always outside react component
+  return <Component3 />
+}
+
+class MyComponent extends Component {
+  public render() {
+    const Component4 = styled.div`
+        color: blue;
+    ` // warnig: styled components should be always outside react component
+    return <Component4 />
+  }
+}
+
+class MyComponent extends Component <Compnent, {}> {
+  public render() {
+    const Component4 = styled.div`
+        color: blue;
+    ` // warnig: styled components should be always outside react component
+    return <Component4 />
+  }
+}
+```

--- a/.grit/patterns/js/warning-for-defined-styled-components-on-module-level.md
+++ b/.grit/patterns/js/warning-for-defined-styled-components-on-module-level.md
@@ -2,7 +2,8 @@
 title: Warning for defined styled components on module level
 ---
 
-Creating a styled component inside the render method in React leads to performance issues because it dynamically generates a new component in the DOM on each render. This causes React to discard and recalculate that part of the DOM subtree every time, rather than efficiently updating only the changed parts. This can result in performance bottlenecks and unpredictable behaviour. 
+Creating a styled component inside the render method in React leads to performance issues because it dynamically generates a new component in the DOM on each render. This causes React to discard and recalculate that part of the DOM subtree every time, rather than efficiently updating only the changed parts. This can result in performance bottlenecks and unpredictable behaviour.
+
 - [reference](https://styled-components.com/docs/faqs#why-should-i-avoid-declaring-styled-components-in-the-render-method)
 
 tags: #react, #migration, #styled-component
@@ -12,17 +13,12 @@ engine marzano(0.1)
 language js
 
 or {
-    react_functional_component($props, $body) where {
-        or {
-            $body <: contains js"styled($component)`$style`" as $styledComponent => `$styledComponent // warnig: styled components should be always outside react component`,
-            $body <: contains js"styled.$tag`$style`" as $styledComponent => `$styledComponent // warnig: styled components should be always outside react component`,
-        }
-    },
-    react_class_component($props, $body) where {
-        or {
-            $body <: contains js"styled($component)`$style`" as $styledComponent => `$styledComponent // warnig: styled components should be always outside react component`,
-            $body <: contains js"styled.$tag`$style`" as $styledComponent => `$styledComponent // warnig: styled components should be always outside react component`,
-        }
+    react_functional_component($props, $body),
+    react_class_component($props, $body)
+} where {
+    or {
+        $body <: contains js"styled($component)`$style`" as $styledComponent => `$styledComponent // warnig: styled components should be always outside react component`,
+        $body <: contains js"styled.$tag`$style`" as $styledComponent => `$styledComponent // warnig: styled components should be always outside react component`,
     }
 }
 ```

--- a/.grit/patterns/js/warning-for-defined-styled-components-on-module-level.md
+++ b/.grit/patterns/js/warning-for-defined-styled-components-on-module-level.md
@@ -2,7 +2,8 @@
 title: Warning for defined styled components on module level
 ---
 
-Creating a styled component inside the render method in React leads to performance issues because it dynamically generates a new component in the DOM on each render. This causes React to discard and recalculate that part of the DOM subtree every time, rather than efficiently updating only the changed parts. This can result in performance bottlenecks and unpredictable behavior.
+Creating a styled component inside the render method in React leads to performance issues because it dynamically generates a new component in the DOM on each render. This causes React to discard and recalculate that part of the DOM subtree every time, rather than efficiently updating only the changed parts. This can result in performance bottlenecks and unpredictable behaviour. 
+- [reference](https://styled-components.com/docs/faqs#why-should-i-avoid-declaring-styled-components-in-the-render-method)
 
 tags: #react, #migration, #styled-component
 


### PR DESCRIPTION
Creating a styled component inside the render method in React leads to performance issues because it dynamically generates a new component in the DOM on each render. This causes React to discard and recalculate that part of the DOM subtree every time, rather than efficiently updating only the changed parts. This can result in performance bottlenecks and unpredictable behaviour. 
- [reference](https://styled-components.com/docs/faqs#why-should-i-avoid-declaring-styled-components-in-the-render-method)

Grit studio link: https://app.grit.io/studio?key=YjIBFhrAb7ao0Zix-Qaao

Note: Hi @morgante, I was trying to re-write the whole component in correct way, but become very tricky, may be we can have an `issue` open for it for future.