### PR TITLE
feat: remove Use of outdated ApolloServer option 'schemaDirectives'

### DIFF
--- a/.grit/patterns/js/remove-apollo-graphql-schema-directives-for-v3-v4.md
+++ b/.grit/patterns/js/remove-apollo-graphql-schema-directives-for-v3-v4.md
@@ -1,0 +1,52 @@
+---
+title: Remove Apollo Graphql Schema Directives while migrating from v2 to v3 or v4
+---
+
+The 'schemaDirectives' option in Apollo GraphQL, which was effective in ApolloServer version v2, no longer functions in versions >=3 and above. This change can have significant implications, potentially exposing authenticated endpoints, disabling rate limiting, and more, depending on the directives used. To address this, it is recommended to consult the references on creating custom directives specifically for ApolloServer versions v3 and v4.
+
+[references](https://www.apollographql.com/docs/apollo-server/schema/directives/#custom-directives)
+
+tags: #fix, #migration
+
+```grit
+engine marzano(0.1)
+language js
+
+`new ApolloServer($props)` where {
+    $props <: contains `schemaDirectives: {$schema}` => .
+}
+```
+
+## Apollo Graphql Schema Directives while migrating from v2 to v3 or v4
+
+```javascript
+// BAD: Has 'schemaDirectives'
+const apollo_server_1 = new ApolloServer({
+    typeDefs,
+    resolvers,
+    schemaDirectives: {
+        rateLimit: rateLimitDirective
+    },
+});
+
+// Good: Does not have 'schemaDirectives'
+const apollo_server_3 = new ApolloServer({
+    typeDefs,
+    resolvers,
+});
+```
+
+```javascript
+// BAD: Has 'schemaDirectives'
+const apollo_server_1 = new ApolloServer({
+    typeDefs,
+    resolvers,
+    
+});
+
+// Good: Does not have 'schemaDirectives'
+const apollo_server_3 = new ApolloServer({
+    typeDefs,
+    resolvers,
+});
+```


### PR DESCRIPTION
The `schemaDirectives` option in `Apollo GraphQL`, which was effective in ApolloServer version `v2`, no longer functions in `versions >=3` and above. This change can have significant implications, potentially exposing authenticated endpoints, disabling rate limiting, and more, depending on the directives used. To address this, it is recommended to consult the references on creating custom directives specifically for ApolloServer versions `v3` and `v4`.

- [references](https://www.apollographql.com/docs/apollo-server/schema/directives/#custom-directives)


grit studio link: https://app.grit.io/studio?key=fzZ0QPNvdajWv-cARmnT7