### PR TITLE
feat: GraphQL Sever v3 csrf prevention

### DIFF
--- a/.grit/patterns/js/graphql-v3-csrf-prevention.md
+++ b/.grit/patterns/js/graphql-v3-csrf-prevention.md
@@ -1,0 +1,71 @@
+---
+title: GraphQL Sever v3 csrf prevention
+---
+
+The Apollo GraphQL server lacks the 'csrfPrevention' option. This option is 'false' by the default in v3 of the Apollo GraphQL v3, which can enable CSRF attacks
+
+tags: #fix #graphQL, #security
+
+```grit
+engine marzano(0.1)
+language js
+
+or {
+    `new ApolloServer({$config})` => `new ApolloServer({
+    $config,
+    csrfPrevention: true
+})` where {
+        $config <: not contains `csrfPrevention: $boolean`
+    },
+    `new ApolloServer({$config})` where {
+        $config <: contains `csrfPrevention: false` => `csrfPrevention: true`
+    },
+}
+```
+
+## GraphQL Sever v3 csrf prevention
+
+```javascript
+// BAD 1: Lacks 'csrfPrevention: true'
+const apollo_server_1 = new ApolloServer({
+  typeDefs,
+  resolvers,
+});
+
+// BAD 2: Has 'csrfPrevention: false'
+const apollo_server_2 = new ApolloServer({
+  typeDefs,
+  resolvers,
+  csrfPrevention: false,
+});
+
+// Good: Has 'csrfPrevention: true'
+const apollo_server_3 = new ApolloServer({
+  typeDefs,
+  resolvers,
+  csrfPrevention: true,
+});
+```
+
+```javascript
+// BAD 1: Lacks 'csrfPrevention: true'
+const apollo_server_1 = new ApolloServer({
+  typeDefs,
+  resolvers,
+  csrfPrevention: true,
+});
+
+// BAD 2: Has 'csrfPrevention: false'
+const apollo_server_2 = new ApolloServer({
+  typeDefs,
+  resolvers,
+  csrfPrevention: true,
+});
+
+// Good: Has 'csrfPrevention: true'
+const apollo_server_3 = new ApolloServer({
+  typeDefs,
+  resolvers,
+  csrfPrevention: true,
+});
+```

--- a/.grit/patterns/js/graphql-v3-csrf-prevention.md
+++ b/.grit/patterns/js/graphql-v3-csrf-prevention.md
@@ -11,12 +11,10 @@ engine marzano(0.1)
 language js
 
 or {
-    `new ApolloServer({$config})` => `new ApolloServer({
-    $config,
-    csrfPrevention: true
-})` where {
-        $config <: not contains `csrfPrevention: $boolean`        
-    },
+    `new ApolloServer({$config})` where {
+	    $config <: not contains `csrfPrevention: $boolean`,
+	    $config += `csrfPrevention: true`
+	},
     `new ApolloServer({$config})` where {
         $config <: contains `csrfPrevention: false` => `csrfPrevention: true`       
     },

--- a/.grit/patterns/js/graphql-v3-csrf-prevention.md
+++ b/.grit/patterns/js/graphql-v3-csrf-prevention.md
@@ -2,7 +2,7 @@
 title: GraphQL Sever v3 csrf prevention
 ---
 
-The Apollo GraphQL server lacks the 'csrfPrevention' option. This option is 'false' by the default in v3 of the Apollo GraphQL v3, which can enable CSRF attacks
+The Apollo GraphQL server lacks the 'csrfPrevention' option. This option is 'false' by the default in v3 of the Apollo GraphQL v3, which can enable CSRF attacks.
 
 tags: #fix #graphQL, #security
 

--- a/.grit/patterns/js/graphql-v3-csrf-prevention.md
+++ b/.grit/patterns/js/graphql-v3-csrf-prevention.md
@@ -15,10 +15,10 @@ or {
     $config,
     csrfPrevention: true
 })` where {
-        $config <: not contains `csrfPrevention: $boolean`
+        $config <: not contains `csrfPrevention: $boolean`        
     },
     `new ApolloServer({$config})` where {
-        $config <: contains `csrfPrevention: false` => `csrfPrevention: true`
+        $config <: contains `csrfPrevention: false` => `csrfPrevention: true`       
     },
 }
 ```
@@ -28,44 +28,44 @@ or {
 ```javascript
 // BAD 1: Lacks 'csrfPrevention: true'
 const apollo_server_1 = new ApolloServer({
-  typeDefs,
-  resolvers,
+    typeDefs,
+    resolvers
 });
 
 // BAD 2: Has 'csrfPrevention: false'
 const apollo_server_2 = new ApolloServer({
-  typeDefs,
-  resolvers,
-  csrfPrevention: false,
+    typeDefs,
+    resolvers, 
+    csrfPrevention: false,
 });
 
 // Good: Has 'csrfPrevention: true'
 const apollo_server_3 = new ApolloServer({
-  typeDefs,
-  resolvers,
-  csrfPrevention: true,
+    typeDefs,
+    resolvers,
+    csrfPrevention: true,
 });
 ```
 
 ```javascript
 // BAD 1: Lacks 'csrfPrevention: true'
 const apollo_server_1 = new ApolloServer({
-  typeDefs,
-  resolvers,
-  csrfPrevention: true,
+    typeDefs,
+    resolvers,
+    csrfPrevention: true
 });
 
 // BAD 2: Has 'csrfPrevention: false'
 const apollo_server_2 = new ApolloServer({
-  typeDefs,
-  resolvers,
-  csrfPrevention: true,
+    typeDefs,
+    resolvers, 
+    csrfPrevention: true,
 });
 
 // Good: Has 'csrfPrevention: true'
 const apollo_server_3 = new ApolloServer({
-  typeDefs,
-  resolvers,
-  csrfPrevention: true,
+    typeDefs,
+    resolvers,
+    csrfPrevention: true,
 });
 ```


### PR DESCRIPTION
The Apollo GraphQL server lacks the `csrfPrevention` option. This option is `false` by the default in v3 of the Apollo GraphQL `v3`, which can enable `CSRF` attacks

Grit studio link: https://app.grit.io/studio?key=zm9i9h90rA1AfLDL-E76C