### PR TITLE
feat: GraphQL Sever v4 csrf prevention

### DIFF
--- a/.grit/patterns/js/graphql-v4-csrf-prevention.md
+++ b/.grit/patterns/js/graphql-v4-csrf-prevention.md
@@ -4,6 +4,8 @@ title: GraphQL Sever v4 csrf prevention
 
 The Apollo GraphQL server sets the 'csrfPrevention' option to false. This can enable CSRF attacks.
 
+- [reference](https://www.apollographql.com/docs/apollo-server/v3/security/cors/#preventing-cross-site-request-forgery-csrf)
+
 tags: #fix #graphQL, #security
 
 ```grit

--- a/.grit/patterns/js/graphql-v4-csrf-prevention.md
+++ b/.grit/patterns/js/graphql-v4-csrf-prevention.md
@@ -1,0 +1,62 @@
+---
+title: GraphQL Sever v4 csrf prevention
+---
+
+The Apollo GraphQL server sets the 'csrfPrevention' option to false. This can enable CSRF attacks.
+
+tags: #fix #graphQL, #security
+
+```grit
+engine marzano(0.1)
+language js
+
+`new ApolloServer($config)` where {
+    $config <: contains `csrfPrevention: false` => `csrfPrevention: true`
+}
+```
+
+## GraphQL Sever v4 csrf prevention
+
+```javascript
+// OK: Lacks 'csrfPrevention: true', but on v4 this option is true by default
+const apollo_server_1 = new ApolloServer({
+  typeDefs,
+  resolvers,
+});
+
+// Good: Has 'csrfPrevention: true'
+const apollo_server_3 = new ApolloServer({
+  typeDefs,
+  resolvers,
+  csrfPrevention: true,
+});
+
+// BAD: Has 'csrfPrevention: false'
+const apollo_server_2 = new ApolloServer({
+  typeDefs,
+  resolvers,
+  csrfPrevention: false,
+});
+```
+
+```javascript
+// OK: Lacks 'csrfPrevention: true', but on v4 this option is true by default
+const apollo_server_1 = new ApolloServer({
+  typeDefs,
+  resolvers,
+});
+
+// Good: Has 'csrfPrevention: true'
+const apollo_server_3 = new ApolloServer({
+  typeDefs,
+  resolvers,
+  csrfPrevention: true,
+});
+
+// BAD: Has 'csrfPrevention: false'
+const apollo_server_2 = new ApolloServer({
+  typeDefs,
+  resolvers,
+  csrfPrevention: true,
+});
+```


### PR DESCRIPTION
The Apollo GraphQL server sets the `csrfPrevention` option to `false`. This can enable CSRF attacks.
- [reference](https://www.apollographql.com/docs/apollo-server/v3/security/cors/#preventing-cross-site-request-forgery-csrf)

Grit studio link: https://app.grit.io/studio?key=wyrCHzl5dIrY8Brrw_qiG