### PR TITLE
feat: update replaceAll to replace when have regex pattern

### DIFF
--- a/.grit/patterns/js/replaceAll_to_replace.md
+++ b/.grit/patterns/js/replaceAll_to_replace.md
@@ -4,7 +4,7 @@ title: Rewrite `replaceAll` ⇒ `replace` when have regex pattern
 
 Replaces `replaceAll` with `replace`, when have regex pattern.
 
-The string method replaceAll is not supported in all versions of javascript, and is not supported by older browser versions. Consider using replace() with a regex as the first argument instead like mystring.replace(/bad/g, "good") instead of mystring.replaceAll("bad", "good") 
+The `replaceAll` string method may not be supported in all JavaScript versions and older browsers. It is advisable to use the `replace()` method with a regular expression as the first argument. For example, use `mystring.replace(/bad/g, "good") `instead of `mystring.replaceAll("bad", "good")`
 
 - [reference](https://discourse.threejs.org/t/replaceall-is-not-a-function/14585)
 

--- a/.grit/patterns/js/replaceAll_to_replace.md
+++ b/.grit/patterns/js/replaceAll_to_replace.md
@@ -1,0 +1,44 @@
+---
+title: Rewrite `replaceAll` ⇒ `replace` when have regex pattern
+---
+
+Replaces `replaceAll` with `replace`, when have regex pattern.
+
+The string method replaceAll is not supported in all versions of javascript, and is not supported by older browser versions. Consider using replace() with a regex as the first argument instead like mystring.replace(/bad/g, "good") instead of mystring.replaceAll("bad", "good") 
+
+- [reference](https://discourse.threejs.org/t/replaceall-is-not-a-function/14585)
+
+tags: #fix
+
+```grit
+engine marzano(0.1)
+language js
+
+`$string.replaceAll("$stringValue", $replaceString)` => `$string.replace("$stringValue", $replaceString)`
+```
+
+## Transforms replaceAll to replace when have regex pattern
+
+```javascript
+const str = 'Hello String';
+// GOOD: replaceAll
+const str1 = old_str1.replaceAll(str, '    ');
+// GOOD: replaceAll
+const str1 = old_str1.replaceAll(hello, '    ');
+// BAD: replaceAll
+const str2 = old_str2.replaceAll('\t', '    ');
+// GOOD: replaceAll
+const str3 = old_str3.replace('\t', '    ');
+```
+
+```javascript
+const str = 'Hello String';
+// GOOD: replaceAll
+const str1 = old_str1.replaceAll(str, '    ');
+// GOOD: replaceAll
+const str1 = old_str1.replaceAll(hello, '    ');
+// BAD: replaceAll
+const str2 = old_str2.replace('\t', '    ');
+// GOOD: replaceAll
+const str3 = old_str3.replace('\t', '    ');
+```

--- a/.grit/patterns/js/replaceAll_to_replace.md
+++ b/.grit/patterns/js/replaceAll_to_replace.md
@@ -14,7 +14,7 @@ tags: #fix
 engine marzano(0.1)
 language js
 
-`$string.replaceAll("$stringValue", $replaceString)` => `$string.replace("$stringValue", $replaceString)`
+`$string.replaceAll("$stringValue", $replaceString)` => `$string.replace(/$stringValue/g, $replaceString)`
 ```
 
 ## Transforms replaceAll to replace when have regex pattern
@@ -29,6 +29,8 @@ const str1 = old_str1.replaceAll(hello, '    ');
 const str2 = old_str2.replaceAll('\t', '    ');
 // GOOD: replaceAll
 const str3 = old_str3.replace('\t', '    ');
+// BAD: replaceAll
+const mystr = mystring.replaceAll('bad', 'good');
 ```
 
 ```javascript
@@ -38,7 +40,9 @@ const str1 = old_str1.replaceAll(str, '    ');
 // GOOD: replaceAll
 const str1 = old_str1.replaceAll(hello, '    ');
 // BAD: replaceAll
-const str2 = old_str2.replace('\t', '    ');
+const str2 = old_str2.replace(/\t/g, '    ');
 // GOOD: replaceAll
 const str3 = old_str3.replace('\t', '    ');
+// BAD: replaceAll
+const mystr = mystring.replace(/bad/g, "good")
 ```


### PR DESCRIPTION
Replaces `replaceAll` with `replace`, when have regex pattern.

The `replaceAll` string method may not be supported in all JavaScript versions and older browsers. It is advisable to use the `replace()` method with a regular expression as the first argument. For example, use `mystring.replace(/bad/g, "good") `instead of `mystring.replaceAll("bad", "good")`

- [reference](https://discourse.threejs.org/t/replaceall-is-not-a-function/14585)

grit studio link: https://app.grit.io/studio?key=7VFZdJlsr0u1nn7_X4Ato