### PR TITLE
feat: replace JSON.stringify to stable json-stable-stringify

### DIFF
--- a/.grit/patterns/js/replace-json-stringify-to-stableStringify.md
+++ b/.grit/patterns/js/replace-json-stringify-to-stableStringify.md
@@ -4,6 +4,10 @@ title: Replace `JSON.stringify` ⇒ `json-stable-stringify`
 
 The JSON.stringify method does not guarantee a stable key ordering, and it is not recommended for reliably producing object keys. It is advisable to use json-stable-stringify instead.
 
+### references
+- [json-stable-stringify](https://www.npmjs.com/package/json-stable-stringify)
+- [stackoverflow](https://stackoverflow.com/a/16168003)
+
 tags: #fix
 
 ```grit

--- a/.grit/patterns/js/replace-json-stringify-to-stableStringify.md
+++ b/.grit/patterns/js/replace-json-stringify-to-stableStringify.md
@@ -1,0 +1,68 @@
+---
+title: Replace `JSON.stringify` ⇒ `json-stable-stringify`
+---
+
+The JSON.stringify method does not guarantee a stable key ordering, and it is not recommended for reliably producing object keys. It is advisable to use json-stable-stringify instead.
+
+tags: #fix
+
+```grit
+engine marzano(0.1)
+language js
+
+`` as $body => `import stableStringify from "json-stable-stringify"; \n\n $body` where {
+    $body <: contains `JSON.stringify` => `stableStringify`
+}
+```
+
+## Replace `JSON.stringify` ⇒ `json-stable-stringify`
+
+```javascript
+
+// BAD: no-stringify-keys
+const stringify = JSON.stringify;
+
+// BAD: no-stringify-keys
+hashed[JSON.stringify(obj)] = obj;
+
+// BAD: no-stringify-keys
+const result = hashed[JSON.stringify(obj)];
+
+// GOOD: no-stringify-keys
+hashed[stringify(obj)] = obj;
+
+// GOOD: no-stringify-keys
+const result = hashed[stringify(obj)];
+
+// GOOD: no-stringify-keys
+hashed[stableStringify(obj)] = obj;
+
+// GOOD: no-stringify-keys
+const result = hashed[stableStringify(obj)]
+```
+
+```javascript
+
+import stableStringify from "json-stable-stringify"; 
+
+ // BAD: no-stringify-keys
+const stringify = stableStringify;
+
+// BAD: no-stringify-keys
+hashed[stableStringify(obj)] = obj;
+
+// BAD: no-stringify-keys
+const result = hashed[stableStringify(obj)];
+
+// GOOD: no-stringify-keys
+hashed[stringify(obj)] = obj;
+
+// GOOD: no-stringify-keys
+const result = hashed[stringify(obj)];
+
+// GOOD: no-stringify-keys
+hashed[stableStringify(obj)] = obj;
+
+// GOOD: no-stringify-keys
+const result = hashed[stableStringify(obj)]
+```

--- a/.grit/patterns/js/replace-json-stringify-to-stableStringify.md
+++ b/.grit/patterns/js/replace-json-stringify-to-stableStringify.md
@@ -2,7 +2,7 @@
 title: Replace `JSON.stringify` ⇒ `json-stable-stringify`
 ---
 
-The JSON.stringify method does not guarantee a stable key ordering, and it is not recommended for reliably producing object keys. It is advisable to use json-stable-stringify instead.
+The `JSON.stringify` method does not guarantee a stable key ordering, and it is not recommended for reliably producing object keys. It is advisable to use `json-stable-stringify` instead.
 
 ### references
 - [json-stable-stringify](https://www.npmjs.com/package/json-stable-stringify)


### PR DESCRIPTION
The `JSON.stringify` method does not guarantee a stable key ordering, and it is not recommended for reliably producing object keys. It is advisable to use `json-stable-stringify` instead.

### references
- [json-stable-stringify](https://www.npmjs.com/package/json-stable-stringify)
- [stackoverflow](https://stackoverflow.com/a/16168003)


grit studio link: https://app.grit.io/studio?key=aTO7jBq1cMOp7MSzurKxT