### PR TITLE
feat: replace `zlib.deflate` ⇒ `zlib.deflateSync`

### DIFF
--- a/.grit/patterns/js/marzano.grit
+++ b/.grit/patterns/js/marzano.grit
@@ -13,6 +13,15 @@ pattern function_like($name, $args, $statements) {
   }
 }
 
+pattern loop_like() {
+  or {
+    `for($a;$b;$c){$body}`,
+    `$arr.forEach(($condition) => {$body})`,
+    `while($condition){$body}`,
+    `do {$body} while($condition)`
+  } 
+}
+
 // All core stdlib functions can be done here
 private pattern before_each_file_stdlib() {
   before_each_file_prep_imports()

--- a/.grit/patterns/js/replace-zlib-deflate-to-zlib-deflateSync.md
+++ b/.grit/patterns/js/replace-zlib-deflate-to-zlib-deflateSync.md
@@ -1,0 +1,94 @@
+---
+title: Replace `zlib.deflate` ⇒ `zlib.deflateSync`
+---
+
+Creating and using a large number of `zlib` objects simultaneously can cause significant memory fragmentation. It is strongly recommended that the results of compression operations be cached or made synchronous to avoid duplication of effort
+
+- [reference](https://nodejs.org/api/zlib.html#zlib_threadpool_usage_and_performance_considerations)
+
+tags: #fix #best-practice
+
+```grit
+engine marzano(0.1)
+language js
+
+or {
+    `for($a;$b;$c){$body}`,
+    `$arr.forEach(($condition) => {$body})`,
+    `while($condition){$body}`,
+    `do {$body} while($condition)`
+} where {
+    $body <: contains `zlib.deflate` => `zlib.deflateSync`
+}
+```
+
+## Replace `zlib.deflate` ⇒ `zlib.deflateSync`
+
+```javascript
+const zlib = require('zlib');
+
+const payload = Buffer.from('This is some data');
+
+for (i = 0; i < 30000; ++i) {
+    // BAD: zlib-async-loop
+    zlib.deflate(payload, (err, buffer) => {});
+}
+
+[1,2,3].forEach((el) => {
+    // BAD: zlib-async-loop
+    zlib.deflate(payload, (err, buffer) => {});
+})
+
+for (i = 0; i < 30000; ++i) {
+    // GOOD: zlib-async-loop
+    zlib.deflateSync(payload);
+}
+
+while(i < 30000){
+  // BAD: zlib-async-loop
+  zlib.deflate(payload, (err, buffer) => {});
+}
+
+do {
+  // BAD: zlib-async-loop
+  zlib.deflate(payload, (err, buffer) => {});
+} while(i < 30000)
+
+// GOOD: zlib-async-loop
+zlib.deflate(payload, (err, buffer) => {});
+
+```
+
+```javascript
+const zlib = require('zlib');
+
+const payload = Buffer.from('This is some data');
+
+for (i = 0; i < 30000; ++i) {
+    // BAD: zlib-async-loop
+    zlib.deflateSync(payload, (err, buffer) => {});
+}
+
+[1,2,3].forEach((el) => {
+    // BAD: zlib-async-loop
+    zlib.deflateSync(payload, (err, buffer) => {});
+})
+
+for (i = 0; i < 30000; ++i) {
+    // GOOD: zlib-async-loop
+    zlib.deflateSync(payload);
+}
+
+while(i < 30000){
+  // BAD: zlib-async-loop
+  zlib.deflateSync(payload, (err, buffer) => {});
+}
+
+do {
+  // BAD: zlib-async-loop
+  zlib.deflateSync(payload, (err, buffer) => {});
+} while(i < 30000)
+
+// GOOD: zlib-async-loop
+zlib.deflate(payload, (err, buffer) => {});
+```

--- a/.grit/patterns/js/replace-zlib-deflate-to-zlib-deflateSync.md
+++ b/.grit/patterns/js/replace-zlib-deflate-to-zlib-deflateSync.md
@@ -12,13 +12,8 @@ tags: #fix #best-practice
 engine marzano(0.1)
 language js
 
-or {
-    `for($a;$b;$c){$body}`,
-    `$arr.forEach(($condition) => {$body})`,
-    `while($condition){$body}`,
-    `do {$body} while($condition)`
-} where {
-    $body <: contains `zlib.deflate` => `zlib.deflateSync`
+`zlib.deflate` as $zlib => `zlib.deflateSync` where {
+    $zlib <: within loop_like()
 }
 ```
 


### PR DESCRIPTION
Creating and using a large number of `zlib` objects simultaneously can cause significant memory fragmentation. It is strongly recommended that the results of compression operations be cached or made synchronous to avoid duplication of effort

- [reference](https://nodejs.org/api/zlib.html#zlib_threadpool_usage_and_performance_considerations)

grit studio link: https://app.grit.io/studio?key=gyYAgSYiiXsJ_ZEsU8S2H