### PR TITLE
feat: warning for hardcoded tmp path

### DIFF
--- a/.grit/patterns/python/warning-for-hardcoded-tmp-path.md
+++ b/.grit/patterns/python/warning-for-hardcoded-tmp-path.md
@@ -1,0 +1,80 @@
+---
+title: Warning for hardcoded tmp path
+---
+
+Detected hardcoded temp directory. Consider using `tempfile.TemporaryFile` instead
+
+- [reference](https://docs.python.org/3/library/tempfile.html#tempfile.TemporaryFile)
+
+#warning #good-practice
+
+```grit
+engine marzano(0.1)
+language python
+
+`open($url, $mode)` as $readPath => `$readPath // BAD: hardcoded tmp path` where {
+    $url <: contains r"(^\/tmp.*)"($badString)
+}
+```
+
+## Warning for hardcoded tmp path
+
+```python
+def test1():
+    f = open("/tmp/blah.txt", 'w')
+    f.write("hello world")
+    f.close()
+
+def test2():
+    f = open("/tmp/blah/blahblah/blah.txt", 'r')
+    data = f.read()
+    f.close()
+
+def test3():
+    f = open("./tmp/blah.txt", 'w')
+    f.write("hello world")
+    f.close()
+
+def test3a():
+    f = open("/var/log/something/else/tmp/blah.txt", 'w')
+    f.write("hello world")
+    f.close()
+
+def test4():
+    with open("/tmp/blah.txt", 'r') as fin:
+        data = fin.read()
+
+def test5():
+    with open("./tmp/blah.txt", 'w') as fout:
+        fout.write("hello world")
+```
+
+```python
+def test1():
+    f = open("/tmp/blah.txt", 'w') // BAD: hardcoded tmp path
+    f.write("hello world")
+    f.close()
+
+def test2():
+    f = open("/tmp/blah/blahblah/blah.txt", 'r') // BAD: hardcoded tmp path
+    data = f.read()
+    f.close()
+
+def test3():
+    f = open("./tmp/blah.txt", 'w')
+    f.write("hello world")
+    f.close()
+
+def test3a():
+    f = open("/var/log/something/else/tmp/blah.txt", 'w')
+    f.write("hello world")
+    f.close()
+
+def test4():
+    with open("/tmp/blah.txt", 'r') // BAD: hardcoded tmp path as fin:
+        data = fin.read()
+
+def test5():
+    with open("./tmp/blah.txt", 'w') as fout:
+        fout.write("hello world")
+```

--- a/.grit/patterns/python/warning-for-hardcoded-tmp-path.md
+++ b/.grit/patterns/python/warning-for-hardcoded-tmp-path.md
@@ -12,9 +12,12 @@ Detected hardcoded temp directory. Consider using `tempfile.TemporaryFile` inste
 engine marzano(0.1)
 language python
 
-`open($url, $mode)` as $readPath => `$readPath // BAD: hardcoded tmp path` where {
+or {
+    `$file = open($url, $mode)`,
+    `with open($url, $mode) as $filePath:`
+} as $readPath  where {
     $url <: contains r"(^\/tmp.*)"($badString)
-}
+} => `# BAD: hardcoded tmp path \n$readPath`
 ```
 
 ## Warning for hardcoded tmp path
@@ -51,12 +54,14 @@ def test5():
 
 ```python
 def test1():
-    f = open("/tmp/blah.txt", 'w') // BAD: hardcoded tmp path
+    # BAD: hardcoded tmp path 
+    f = open("/tmp/blah.txt", 'w')
     f.write("hello world")
     f.close()
 
 def test2():
-    f = open("/tmp/blah/blahblah/blah.txt", 'r') // BAD: hardcoded tmp path
+    # BAD: hardcoded tmp path 
+    f = open("/tmp/blah/blahblah/blah.txt", 'r')
     data = f.read()
     f.close()
 
@@ -71,7 +76,8 @@ def test3a():
     f.close()
 
 def test4():
-    with open("/tmp/blah.txt", 'r') // BAD: hardcoded tmp path as fin:
+    # BAD: hardcoded tmp path 
+    with open("/tmp/blah.txt", 'r') as fin:
         data = fin.read()
 
 def test5():


### PR DESCRIPTION
Detected hardcoded temp directory. Consider using `tempfile.TemporaryFile` instead

- [reference](https://docs.python.org/3/library/tempfile.html#tempfile.TemporaryFile)

grit studio link: https://app.grit.io/studio?key=NH1Hr1ZrIrtO2VBOwtfcB