### PR TITLE
feat: close file object opened and never closed

### DIFF
--- a/.grit/patterns/js/replaceAll_to_replace.md
+++ b/.grit/patterns/js/replaceAll_to_replace.md
@@ -1,0 +1,48 @@
+---
+title: Rewrite `replaceAll` ⇒ `replace` when have regex pattern
+---
+
+Replaces `replaceAll` with `replace`, when have regex pattern.
+
+The `replaceAll` string method may not be supported in all JavaScript versions and older browsers. It is advisable to use the `replace()` method with a regular expression as the first argument. For example, use `mystring.replace(/bad/g, "good") `instead of `mystring.replaceAll("bad", "good")`
+
+- [reference](https://discourse.threejs.org/t/replaceall-is-not-a-function/14585)
+
+tags: #fix
+
+```grit
+engine marzano(0.1)
+language js
+
+`$string.replaceAll("$stringValue", $replaceString)` => `$string.replace(/$stringValue/g, $replaceString)`
+```
+
+## Transforms replaceAll to replace when have regex pattern
+
+```javascript
+const str = 'Hello String';
+// GOOD: replaceAll
+const str1 = old_str1.replaceAll(str, '    ');
+// GOOD: replaceAll
+const str1 = old_str1.replaceAll(hello, '    ');
+// BAD: replaceAll
+const str2 = old_str2.replaceAll('\t', '    ');
+// GOOD: replaceAll
+const str3 = old_str3.replace('\t', '    ');
+// BAD: replaceAll
+const mystr = mystring.replaceAll('bad', 'good');
+```
+
+```javascript
+const str = 'Hello String';
+// GOOD: replaceAll
+const str1 = old_str1.replaceAll(str, '    ');
+// GOOD: replaceAll
+const str1 = old_str1.replaceAll(hello, '    ');
+// BAD: replaceAll
+const str2 = old_str2.replace(/\t/g, '    ');
+// GOOD: replaceAll
+const str3 = old_str3.replace('\t', '    ');
+// BAD: replaceAll
+const mystr = mystring.replace(/bad/g, "good")
+```

--- a/.grit/patterns/python/open-file-object-never-closed.md
+++ b/.grit/patterns/python/open-file-object-never-closed.md
@@ -1,0 +1,93 @@
+---
+title: Close file object opened and never closed
+---
+
+We should close the file object opened without corresponding close.
+
+#fix #good-practice
+
+```grit
+engine marzano(0.1)
+language python
+
+`def $func():` as $function where {
+    and {
+        $function <: contains or {
+                `$f = open($parms)`,
+                `$f = io.open($parms)`,
+                `$f = tarfile.open($parms)`,
+                `$f = ZipFile.open($parms)`,
+                `$f = tempfile.TemporaryFile($parms)`,
+                `$f = tempfile.NamedTemporaryFile($parms)`,
+                `$f = tempfile.SpooledTemporaryFile($parms)`,
+            },
+        $function <: not contains `$f.close()`
+    },
+    $function => `$function \n    $f.close()`
+}
+```
+
+## File object opened never closed
+
+```python
+def func1():
+    # BAD: open-never-closed
+    fd = open('foo')
+    x = 123
+    
+def func1():
+    # BAD: open-never-closed
+    fd = tarfile.open('foo')
+    x = 123    
+  
+def func1():
+    # BAD: open-never-closed
+    fd = tempfile.SpooledTemporaryFile('foo')
+    x = 123    
+
+def func2():
+    # GOOD:open-never-closed
+    fd = open('bar')
+    fd.close()
+
+def func3():
+    # GOOD: open-never-closed
+    fd = open('baz')
+    try:
+        pass
+    finally:
+        fd.close()
+```
+
+```python
+def func1():
+    # BAD: open-never-closed
+    fd = open('foo')
+    x = 123 
+    fd.close()
+    
+def func1():
+    # BAD: open-never-closed
+    fd = tarfile.open('foo')
+    x = 123 
+    fd.close()    
+  
+def func1():
+    # BAD: open-never-closed
+    fd = tempfile.SpooledTemporaryFile('foo')
+    x = 123 
+    fd.close()    
+
+def func2():
+    # GOOD:open-never-closed
+    fd = open('bar')
+    fd.close()
+
+def func3():
+    # GOOD: open-never-closed
+    fd = open('baz')
+    try:
+        pass
+    finally:
+        fd.close()
+```

--- a/.grit/patterns/python/open-file-object-never-closed.md
+++ b/.grit/patterns/python/open-file-object-never-closed.md
@@ -39,13 +39,31 @@ def func1():
     
 def func1():
     # BAD: open-never-closed
-    fd = tarfile.open('foo')
+    fdd = tarfile.open('foo')
     x = 123    
   
 def func1():
     # BAD: open-never-closed
-    fd = tempfile.SpooledTemporaryFile('foo')
-    x = 123    
+    fd22 = tempfile.SpooledTemporaryFile('foo')
+    x = 123 
+
+
+def test4():
+    # GOOD: close-not-needed
+    with open("/tmp/blah.txt", 'r') as fin:
+        data = fin.read()       
+
+def test4():
+    # GOOD: close-not-needed
+    with io.open("/tmp/blah.txt", 'r') as fin:
+        data = fin.read()    
+
+def test4():
+    # GOOD: close-not-needed
+    with empfile.TemporaryFile("/tmp/blah.txt", 'r') as fin:
+        data = fin.read()    
+
+
 
 def func2():
     # GOOD:open-never-closed
@@ -70,15 +88,33 @@ def func1():
     
 def func1():
     # BAD: open-never-closed
-    fd = tarfile.open('foo')
+    fdd = tarfile.open('foo')
     x = 123 
-    fd.close()    
+    fdd.close()    
   
 def func1():
     # BAD: open-never-closed
-    fd = tempfile.SpooledTemporaryFile('foo')
+    fd22 = tempfile.SpooledTemporaryFile('foo')
     x = 123 
-    fd.close()    
+    fd22.close() 
+
+
+def test4():
+    # GOOD: close-not-needed
+    with open("/tmp/blah.txt", 'r') as fin:
+        data = fin.read()       
+
+def test4():
+    # GOOD: close-not-needed
+    with io.open("/tmp/blah.txt", 'r') as fin:
+        data = fin.read()    
+
+def test4():
+    # GOOD: close-not-needed
+    with empfile.TemporaryFile("/tmp/blah.txt", 'r') as fin:
+        data = fin.read()    
+
+
 
 def func2():
     # GOOD:open-never-closed

--- a/.grit/patterns/python/open-file-object-never-closed.md
+++ b/.grit/patterns/python/open-file-object-never-closed.md
@@ -4,6 +4,8 @@ title: Close file object opened and never closed
 
 We should close the file object opened without corresponding close.
 
+- [reference](https://realpython.com/why-close-file-python/)
+
 #fix #good-practice
 
 ```grit


### PR DESCRIPTION
We should close the file object opened without corresponding close.

- [reference](https://realpython.com/why-close-file-python/)

grit studio link: https://app.grit.io/studio?key=3x1Ab-H2gVgzopAcZ4YJN