### PR TITLE
feat: replace `tempfile.mktemp` ⇒ `tempfile.NamedTemporaryFile`

### DIFF
--- a/.grit/patterns/python/replace-tempfile-mktemp-with-tempfile-NamedTemporaryFile.md
+++ b/.grit/patterns/python/replace-tempfile-mktemp-with-tempfile-NamedTemporaryFile.md
@@ -12,7 +12,12 @@ tags: #fix #good-practice
 engine marzano(0.1)
 language python
 
-`$tempfile.mktemp` => `$tempfile.NamedTemporaryFile`
+and {
+    `$tempfile.mktemp($params)` => `$tempfile.NamedTemporaryFile($params delete=False)`,
+    `$tempfile.mktemp($params)` where {
+        $params => `$params ,`,
+    }
+}
 ```
 
 ## Replace `tempfile.mktemp` ⇒ `tempfile.NamedTemporaryFile`
@@ -31,8 +36,8 @@ x = tempfile.mktemp(dir="/tmp")
 import tempfile as tf
 
 # BAD: tempfile-insecure
-x = tempfile.NamedTemporaryFile()
+x = tempfile.NamedTemporaryFile( delete=False)
 
 # BAD: tempfile-insecure
-x = tempfile.NamedTemporaryFile(dir="/tmp")
+x = tempfile.NamedTemporaryFile(dir="/tmp" , delete=False)
 ```

--- a/.grit/patterns/python/replace-tempfile-mktemp-with-tempfile-NamedTemporaryFile.md
+++ b/.grit/patterns/python/replace-tempfile-mktemp-with-tempfile-NamedTemporaryFile.md
@@ -1,0 +1,38 @@
+---
+title: Replace `tempfile.mktemp` ⇒ `tempfile.NamedTemporaryFile`
+---
+
+Prefer using tempfile.NamedTemporaryFile instead. According to the official Python documentation, the tempfile.mktemp function is considered unsafe and should be avoided. This is because the generated file name may initially point to a non-existent file, and by the time you attempt to create it, another process may have already created a file with the same name, leading to potential conflicts.
+
+- [reference](https://docs.python.org/3/library/tempfile.html#tempfile.mkdtemp)
+
+tags: #fix #good-practice
+
+```grit
+engine marzano(0.1)
+language python
+
+`$tempfile.mktemp` => `$tempfile.NamedTemporaryFile`
+```
+
+## Replace `tempfile.mktemp` ⇒ `tempfile.NamedTemporaryFile`
+
+```python
+import tempfile as tf
+
+# BAD: tempfile-insecure
+x = tempfile.mktemp()
+
+# BAD: tempfile-insecure
+x = tempfile.mktemp(dir="/tmp")
+```
+
+```python
+import tempfile as tf
+
+# BAD: tempfile-insecure
+x = tempfile.NamedTemporaryFile()
+
+# BAD: tempfile-insecure
+x = tempfile.NamedTemporaryFile(dir="/tmp")
+```

--- a/.grit/patterns/python/replace_tempfile.md
+++ b/.grit/patterns/python/replace_tempfile.md
@@ -12,10 +12,10 @@ tags: #fix #good-practice
 engine marzano(0.1)
 language python
 
-and {
-    `$tempfile.mktemp($params)` => `$tempfile.NamedTemporaryFile($params delete=False)`,
-    `$tempfile.mktemp($params)` where {
-        $params => `$params ,`,
+`$tempfile.mktemp($params)` => `$tempfile.NamedTemporaryFile($[params]delete=False)` where {
+    // If $params is present, add the comma
+    if ($params <: not .) {
+        $params => `$params, `
     }
 }
 ```
@@ -36,8 +36,8 @@ x = tempfile.mktemp(dir="/tmp")
 import tempfile as tf
 
 # BAD: tempfile-insecure
-x = tempfile.NamedTemporaryFile( delete=False)
+x = tempfile.NamedTemporaryFile(delete=False)
 
 # BAD: tempfile-insecure
-x = tempfile.NamedTemporaryFile(dir="/tmp" , delete=False)
+x = tempfile.NamedTemporaryFile(dir="/tmp", delete=False)
 ```


### PR DESCRIPTION
Prefer using `tempfile.NamedTemporaryFile` instead. According to the official Python documentation, the `tempfile.mktemp` function is considered unsafe and should be avoided. This is because the generated file name may initially point to a non-existent file, and by the time you attempt to create it, another process may have already created a file with the same name, leading to potential conflicts.

- [reference](https://docs.python.org/3/library/tempfile.html#tempfile.mkdtemp)


grit studio link: https://app.grit.io/studio?key=FSpX6ou9ZdSg2icZaFO_L