### PR TITLE
chore: update no debugger pattern

### DIFF
--- a/.grit/patterns/python/py_no_debugger.md
+++ b/.grit/patterns/python/py_no_debugger.md
@@ -10,13 +10,14 @@ tags: #fix #good-practice
 engine marzano(0.1)
 language python
 
-file($name, $body) where {
-    any {
-        $body <: contains `import pdb as $db` => .,
-        $body <: contains `import pdb` => .,
-        $body <: contains `$db.set_trace()` => .,
-        $body <: contains `pdb.Pdb.set_trace()` => .,
-        $body <: contains `$db.Pdb.set_trace()` => .,
+or {
+  `import $pdb as $db`,
+  `import pdb` where $db = `pdb`
+} where {
+    $program <: maybe contains or {
+        `$db.set_trace()` => .,
+        `$db.Pdb.set_trace()` => .,
+        `$pdb.Pdb.set_trace()` => .,
     }
 }
 ```
@@ -43,7 +44,7 @@ def foo():
 ```
 
 ```python
-
+import pdb as db
 
 
 def foo():
@@ -56,7 +57,7 @@ def foo():
     pdb = "also a string"
     # BAD: pdb-remove
     # BAD: pdb-remove
-
+    
 ```
 
 ## Remove debugger direct import
@@ -76,6 +77,7 @@ def foo():
 
 ```python
 # BAD: python-debugger-found
+import pdb
 
 # BAD: python-debugger-found
 

--- a/.grit/patterns/python/py_no_debugger.md
+++ b/.grit/patterns/python/py_no_debugger.md
@@ -12,13 +12,13 @@ language python
 
 file($name, $body) where {
      or {
-        and {
+        any {
             $body <: contains `import pdb as $db` => .,
             $body <: contains `$db.set_trace()` => .,
             $body <: contains `pdb.Pdb.set_trace()` => .,
             $body <: contains `$db.Pdb.set_trace()` => .,
         },
-        and {
+        any {
             $body <: contains `import pdb` => .,
             $body <: contains `pdb.set_trace()` => .
         }

--- a/.grit/patterns/python/py_no_debugger.md
+++ b/.grit/patterns/python/py_no_debugger.md
@@ -11,14 +11,60 @@ engine marzano(0.1)
 language python
 
 `` as $body where {
-    and {
-        $body <: contains `import pdb` => .,
-        $body <: contains `pdb.set_trace()` => .
+    or {
+        and {
+            $body <: contains `import pdb as $db` => .,
+            $body <: contains `$db.set_trace()` => .,
+            $body <: contains `pdb.Pdb.set_trace()` => .,
+            $body <: contains `$db.Pdb.set_trace()` => .,
+        },
+        and {
+            $body <: contains `import pdb` => .,
+            $body <: contains `pdb.set_trace()` => .
+        }
     }
 }
 ```
 
-## Remove debugger
+## Remove debugger direct as import
+
+```python
+import pdb as db
+
+
+def foo():
+    # BAD: pdb-remove
+    db.set_trace()
+
+    a = "apple"
+
+    db = "the string, not the library"
+    #ok:pdb-remove
+    pdb = "also a string"
+    # BAD: pdb-remove
+    pdb.Pdb.set_trace()
+    # BAD: pdb-remove
+    db.Pdb.set_trace(...)
+```
+
+```python
+
+
+
+def foo():
+    # BAD: pdb-remove
+
+    a = "apple"
+
+    db = "the string, not the library"
+    #ok:pdb-remove
+    pdb = "also a string"
+    # BAD: pdb-remove
+    # BAD: pdb-remove
+    
+```
+
+## Remove debugger direct import
 
 ```python
 # BAD: python-debugger-found

--- a/.grit/patterns/python/py_no_debugger.md
+++ b/.grit/patterns/python/py_no_debugger.md
@@ -11,17 +11,12 @@ engine marzano(0.1)
 language python
 
 file($name, $body) where {
-     or {
-        any {
-            $body <: contains `import pdb as $db` => .,
-            $body <: contains `$db.set_trace()` => .,
-            $body <: contains `pdb.Pdb.set_trace()` => .,
-            $body <: contains `$db.Pdb.set_trace()` => .,
-        },
-        any {
-            $body <: contains `import pdb` => .,
-            $body <: contains `pdb.set_trace()` => .
-        }
+    any {
+        $body <: contains `import pdb as $db` => .,
+        $body <: contains `import pdb` => .,
+        $body <: contains `$db.set_trace()` => .,
+        $body <: contains `pdb.Pdb.set_trace()` => .,
+        $body <: contains `$db.Pdb.set_trace()` => .,
     }
 }
 ```
@@ -61,7 +56,7 @@ def foo():
     pdb = "also a string"
     # BAD: pdb-remove
     # BAD: pdb-remove
-    
+
 ```
 
 ## Remove debugger direct import

--- a/.grit/patterns/python/py_no_debugger.md
+++ b/.grit/patterns/python/py_no_debugger.md
@@ -10,19 +10,13 @@ tags: #fix #good-practice
 engine marzano(0.1)
 language python
 
-`` as $body where {
-    or {
-        and {
-            $body <: contains `import pdb as $db` => .,
-            $body <: contains `$db.set_trace()` => .,
-            $body <: contains `pdb.Pdb.set_trace()` => .,
-            $body <: contains `$db.Pdb.set_trace()` => .,
-        },
-        and {
-            $body <: contains `import pdb` => .,
-            $body <: contains `pdb.set_trace()` => .
-        }
-    }
+or {
+    `import pdb as $db` => .,
+    `$db.set_trace()` => .,
+    `$db.Pdb.set_trace()` => .,
+    `pdb.Pdb.set_trace()` => .,
+    `import pdb` => .,
+    `$p = $db.set_trace()` => .
 }
 ```
 
@@ -87,5 +81,5 @@ def foo():
 
 def foo():
     # GOOD: python-debugger-found
-    p = not_pdb.set_trace()
+    
 ```

--- a/.grit/patterns/python/py_no_debugger.md
+++ b/.grit/patterns/python/py_no_debugger.md
@@ -10,13 +10,19 @@ tags: #fix #good-practice
 engine marzano(0.1)
 language python
 
-or {
-    `import pdb as $db` => .,
-    `$db.set_trace()` => .,
-    `$db.Pdb.set_trace()` => .,
-    `pdb.Pdb.set_trace()` => .,
-    `import pdb` => .,
-    `$p = $db.set_trace()` => .
+file($name, $body) where {
+     or {
+        and {
+            $body <: contains `import pdb as $db` => .,
+            $body <: contains `$db.set_trace()` => .,
+            $body <: contains `pdb.Pdb.set_trace()` => .,
+            $body <: contains `$db.Pdb.set_trace()` => .,
+        },
+        and {
+            $body <: contains `import pdb` => .,
+            $body <: contains `pdb.set_trace()` => .
+        }
+    }
 }
 ```
 
@@ -81,5 +87,5 @@ def foo():
 
 def foo():
     # GOOD: python-debugger-found
-    
+    p = not_pdb.set_trace()
 ```


### PR DESCRIPTION
We should remove debugger from production code

updated it for `as` import also.
ex: `import pdb as db`

grit studio link: https://app.grit.io/studio?key=6FUWscU-mNmbGp3M_WBKg