### PR TITLE
feat: Avoid unnecessary if statements

### DIFF
--- a/.grit/patterns/go/no_unnecessary_conditionals.md
+++ b/.grit/patterns/go/no_unnecessary_conditionals.md
@@ -1,8 +1,8 @@
 ---
-title: Warning for bad comparison if (True), if (False)
+title: Avoid unnecessary if statements
 ---
 
-Identified redundant if statement: `if (True)`, `if (False)` consistently yield the same outcome, making one of the expressions unnecessary in the code. Remove either the `if (False)` segment entirely or the `if (True)` comparison, depending on which is present in the code.
+If statements that always evaluate to `true` or `false` are redundant and should be removed.
 
 tags: #fix #warning
 
@@ -10,13 +10,9 @@ tags: #fix #warning
 language go
 
 or {
-    `if(false){
-        $body
-    }`,
-    `if(true){
-        $body
-    }` 
-} as $comp => `// INCORRECT: comparison \n $comp`
+	`if(false){ $body }` => .,
+	`if(true){ $body }`  => $body
+}
 ```
 
 ## Warning for INCORRECT comparison `if (True)`
@@ -45,10 +41,7 @@ func mainFunc() {
     fmt.Println("hello world")
     var y = "hello";
 
-    // INCORRECT: comparison 
- if (true) {
-        fmt.Println("never")
-    }
+    fmt.Println("never")
 }
 ```
 
@@ -80,9 +73,5 @@ func mainFunc() {
     fmt.Println("hello world")
     var y = "hello";
 
-    // INCORRECT: comparison 
- if (false) {
-        fmt.Println("never")
-    }
 }
 ```

--- a/.grit/patterns/go/warning_bad_comparison.md
+++ b/.grit/patterns/go/warning_bad_comparison.md
@@ -1,0 +1,71 @@
+---
+title: Warning for bad comparison $x == $x, if (True), if (False)
+---
+
+Identified redundant if statement: `if (True)`, `if (False)` and `$x == $x` consistently yield the same outcome, making one of the expressions unnecessary in the code. Remove either the `if (False)` segment entirely or the `if (True)` comparison, depending on which is present in the code.
+
+tags: #fix #warning
+
+```grit
+language go
+
+or {
+    `$func($x == $x)`,
+    `if(false){
+        $body
+    }`,
+    `if(true){
+        $body
+    }`
+} as $comp => `// BAD: comparison \n $comp`
+```
+
+## Warning for bad comparison `$x == $x`, `if (True)`, `if (False)`
+
+```go
+package main
+
+import "fmt"
+
+func mainFunc() {
+    fmt.Println("hello world")
+    var y = "hello";
+    fmt.Println(y == y)
+
+    assert(y == y)
+
+    if (false) {
+        fmt.Println("never")
+    }
+
+    if (true) {
+        fmt.Println("never")
+    }
+}
+```
+
+```go
+package main
+
+import "fmt"
+
+func mainFunc() {
+    fmt.Println("hello world")
+    var y = "hello";
+    // BAD: comparison
+ fmt.Println(y == y)
+
+    // BAD: comparison
+ assert(y == y)
+
+    // BAD: comparison
+ if (false) {
+        fmt.Println("never")
+    }
+
+    // BAD: comparison
+ if (true) {
+        fmt.Println("never")
+    }
+}
+```

--- a/.grit/patterns/go/warning_bad_comparison.md
+++ b/.grit/patterns/go/warning_bad_comparison.md
@@ -16,10 +16,10 @@ or {
     `if(true){
         $body
     }` 
-} as $comp => `// BAD: comparison \n $comp`
+} as $comp => `// INCORRECT: comparison \n $comp`
 ```
 
-## Warning for bad comparison `if (True)` and `if (False)`
+## Warning for INCORRECT comparison `if (True)`
 
 ```go
 package main
@@ -29,10 +29,6 @@ import "fmt"
 func mainFunc() {
     fmt.Println("hello world")
     var y = "hello";
-
-    if (false) {
-        fmt.Println("never")
-    }
 
     if (true) {
         fmt.Println("never")
@@ -49,13 +45,43 @@ func mainFunc() {
     fmt.Println("hello world")
     var y = "hello";
 
-    // BAD: comparison 
- if (false) {
+    // INCORRECT: comparison 
+ if (true) {
         fmt.Println("never")
     }
+}
+```
 
-    // BAD: comparison 
- if (true) {
+
+## Warning for INCORRECT comparison `if (False)`
+
+```go
+package main
+
+import "fmt"
+
+func mainFunc() {
+    fmt.Println("hello world")
+    var y = "hello";
+
+    if (false) {
+        fmt.Println("never")
+    }
+}
+```
+
+
+```go
+package main
+
+import "fmt"
+
+func mainFunc() {
+    fmt.Println("hello world")
+    var y = "hello";
+
+    // INCORRECT: comparison 
+ if (false) {
         fmt.Println("never")
     }
 }

--- a/.grit/patterns/go/warning_bad_comparison.md
+++ b/.grit/patterns/go/warning_bad_comparison.md
@@ -1,8 +1,8 @@
 ---
-title: Warning for bad comparison $x == $x, if (True), if (False)
+title: Warning for bad comparison if (True), if (False)
 ---
 
-Identified redundant if statement: `if (True)`, `if (False)` and `$x == $x` consistently yield the same outcome, making one of the expressions unnecessary in the code. Remove either the `if (False)` segment entirely or the `if (True)` comparison, depending on which is present in the code.
+Identified redundant if statement: `if (True)`, `if (False)` consistently yield the same outcome, making one of the expressions unnecessary in the code. Remove either the `if (False)` segment entirely or the `if (True)` comparison, depending on which is present in the code.
 
 tags: #fix #warning
 
@@ -10,17 +10,16 @@ tags: #fix #warning
 language go
 
 or {
-    `$func($x == $x)`,
     `if(false){
         $body
     }`,
     `if(true){
         $body
-    }`
+    }` 
 } as $comp => `// BAD: comparison \n $comp`
 ```
 
-## Warning for bad comparison `$x == $x`, `if (True)`, `if (False)`
+## Warning for bad comparison `if (True)` and `if (False)`
 
 ```go
 package main
@@ -30,9 +29,6 @@ import "fmt"
 func mainFunc() {
     fmt.Println("hello world")
     var y = "hello";
-    fmt.Println(y == y)
-
-    assert(y == y)
 
     if (false) {
         fmt.Println("never")
@@ -52,18 +48,13 @@ import "fmt"
 func mainFunc() {
     fmt.Println("hello world")
     var y = "hello";
-    // BAD: comparison
- fmt.Println(y == y)
 
-    // BAD: comparison
- assert(y == y)
-
-    // BAD: comparison
+    // BAD: comparison 
  if (false) {
         fmt.Println("never")
     }
 
-    // BAD: comparison
+    // BAD: comparison 
  if (true) {
         fmt.Println("never")
     }


### PR DESCRIPTION
Identified redundant if statement: `if (True)`, `if (False)`  consistently yield the same outcome, making one of the expressions unnecessary in the code. Remove either the `if (False)` segment entirely or the `if (True)` comparison, depending on which is present in the code.

grit studio link: https://app.grit.io/studio?key=lgKcxKqerGulQp-9rAZQo