### PR TITLE
feat: useless if conditional

### DIFF
--- a/.grit/patterns/go/useless_if_else_body.md
+++ b/.grit/patterns/go/useless_if_else_body.md
@@ -2,7 +2,7 @@
 title: Identical statements in the if else body
 ---
 
-Identical statements found in both the if and else bodies of an if-statement. This results in the same code execution regardless of the if-expression outcome. To optimize, eliminate the if statement entirely.
+Identical statements found in both the `if` and `else` bodies of an `if-statement`. This results in the same code execution regardless of the if-expression outcome. To optimize, eliminate the `if` statement entirely.
 
 tags: #fix #correctness
 

--- a/.grit/patterns/go/useless_if_else_body.md
+++ b/.grit/patterns/go/useless_if_else_body.md
@@ -17,7 +17,7 @@ or {
 }`
 ```
 
-## Detected identical statements in the if body
+## Detected identical statements in the else if
 
 ```go
 package main
@@ -31,25 +31,13 @@ func main() {
 		fmt.Println("of course")
 	}
 
-	// BAD: useless-if-conditional
+	// useless-if-conditional
 	if (y) {
 		fmt.Println("same condition")
 	} else if (y) {
 		fmt.Println("same condition")
 	}
-	// BAD: useless-if-body
-	if (y) {
-		fmt.Println("of course")
-	} else {
-		fmt.Println("of course")
-	}
-
-	// GOOD: useless-if-body
-	if (y) {
-		fmt.Println("of course")
-	} else {
-		fmt.Println("different condition")
-	}
+	
 }
 ```
 
@@ -65,16 +53,76 @@ func main() {
 		fmt.Println("of course")
 	}
 
-	// BAD: useless-if-conditional
+	// useless-if-conditional
 	if (y) { 
     fmt.Println("same condition") 
 }
-	// BAD: useless-if-body
+	
+}
+```
+
+## Detected identical statements in the if else
+
+```go
+package main
+
+import "fmt"
+
+func main() {
+	var y = 1
+
+	// useless-if-body
+	if (y) {
+		fmt.Println("of course")
+	} else {
+		fmt.Println("of course")
+	}
+}
+```
+
+
+```go
+package main
+
+import "fmt"
+
+func main() {
+	var y = 1
+
+	// useless-if-body
 	if (y) { 
     fmt.Println("of course") 
 }
+}
+```
 
-	// GOOD: useless-if-body
+## Detected identical statements in the different if else
+
+```go
+package main
+
+import "fmt"
+
+func main() {
+	var y = 1
+	
+	if (y) {
+		fmt.Println("of course")
+	} else {
+		fmt.Println("different condition")
+	}
+}
+```
+
+
+```go
+package main
+
+import "fmt"
+
+func main() {
+	var y = 1
+	
 	if (y) {
 		fmt.Println("of course")
 	} else {

--- a/.grit/patterns/go/useless_if_else_body.md
+++ b/.grit/patterns/go/useless_if_else_body.md
@@ -1,0 +1,84 @@
+---
+title: Identical statements in the if else body
+---
+
+Identical statements found in both the if and else bodies of an if-statement. This results in the same code execution regardless of the if-expression outcome. To optimize, eliminate the if statement entirely.
+
+tags: #fix #correctness
+
+```grit
+language go
+
+or {
+    `if ($conditon) { $body } else { $body }`,
+    `if ($conditon) { $body } else if ($conditon) { $body }`
+} => `if ($conditon) { 
+    $body 
+}`
+```
+
+## Detected identical statements in the if body
+
+```go
+package main
+
+import "fmt"
+
+func main() {
+	var y = 1
+
+	if (y) {
+		fmt.Println("of course")
+	}
+
+	// BAD: useless-if-conditional
+	if (y) {
+		fmt.Println("same condition")
+	} else if (y) {
+		fmt.Println("same condition")
+	}
+	// BAD: useless-if-body
+	if (y) {
+		fmt.Println("of course")
+	} else {
+		fmt.Println("of course")
+	}
+
+	// GOOD: useless-if-body
+	if (y) {
+		fmt.Println("of course")
+	} else {
+		fmt.Println("different condition")
+	}
+}
+```
+
+```go
+package main
+
+import "fmt"
+
+func main() {
+	var y = 1
+
+	if (y) {
+		fmt.Println("of course")
+	}
+
+	// BAD: useless-if-conditional
+	if (y) { 
+    fmt.Println("same condition") 
+}
+	// BAD: useless-if-body
+	if (y) { 
+    fmt.Println("of course") 
+}
+
+	// GOOD: useless-if-body
+	if (y) {
+		fmt.Println("of course")
+	} else {
+		fmt.Println("different condition")
+	}
+}
+```


### PR DESCRIPTION
Identical statements found in both the `if` and `else` bodies of an `if-statement`. This results in the same code execution regardless of the if-expression outcome. To optimize, eliminate the `if` statement entirely.

grit studio link: https://app.grit.io/studio?key=EyccL37fsQzbsuzKLQEdD