### PR TITLE
feat: replace `path.Join()` ⇒ `filepath.Join()`

### DIFF
--- a/.grit/patterns/go/go_imports.grit
+++ b/.grit/patterns/go/go_imports.grit
@@ -1,0 +1,10 @@
+language go
+
+/** This is a utility file, you do not need to implement it yourself */
+
+pattern ensure_import($source) {
+    import_declaration(imports=import_spec_list(imports=$mod)) where {
+        $mod <: not contains $source,
+        $mod => `$mod\n$source`
+    }
+}

--- a/.grit/patterns/go/path_to_filepath.md
+++ b/.grit/patterns/go/path_to_filepath.md
@@ -1,0 +1,91 @@
+---
+title: Replace `path.Join()` ⇒ `filepath.Join()`
+---
+
+Utilize `filepath.Join(...)` instead of `path.Join(...)` as it accommodates OS-specific path separators, mitigating potential issues on systems like Windows that may employ different delimiters.
+
+### references
+
+- [strconv](https://pkg.go.dev/strconv)
+
+tags: #fix #correctness
+
+```grit
+language go
+
+`path.Join($params)` => `filepath.Join($params)`
+```
+
+## Replace `path.Join()` ⇒ `filepath.Join()`
+
+```go
+package main
+
+import (
+	"fmt"
+	"path"
+	"path/filepath"
+)
+
+func getDirectory() string {
+	return "/some/directory" // Replace this with your logic to get the directory
+}
+
+func exampleFunction1() {
+	dir := getDirectory()
+
+	var joinedPath = path.Join(getDirectory())
+
+	var filePath = filepath.Join(getDirectory())
+
+	path.Join("/", path.Base(joinedPath))
+}
+
+func exampleFunction2() {
+	fmt.Println(path.Join(url.Path, "baz"))
+}
+
+func exampleFunction3(p string) {
+	fmt.Println(path.Join(p, "baz"))
+
+	fmt.Println(path.Join("asdf", "baz"))
+
+	fmt.Println(filepath.Join(a.Path, "baz"))
+}
+```
+
+```go
+package main
+
+import (
+	"fmt"
+	"path"
+	"path/filepath"
+)
+
+func getDirectory() string {
+	return "/some/directory" // Replace this with your logic to get the directory
+}
+
+func exampleFunction1() {
+	dir := getDirectory()
+
+	var joinedPath = filepath.Join(getDirectory())
+
+	var filePath = filepath.Join(getDirectory())
+
+	filepath.Join("/", path.Base(joinedPath))
+}
+
+func exampleFunction2() {
+	fmt.Println(filepath.Join(url.Path, "baz"))
+}
+
+func exampleFunction3(p string) {
+	fmt.Println(filepath.Join(p, "baz"))
+
+	fmt.Println(filepath.Join("asdf", "baz"))
+
+	fmt.Println(filepath.Join(a.Path, "baz"))
+}
+```

--- a/.grit/patterns/go/path_to_filepath.md
+++ b/.grit/patterns/go/path_to_filepath.md
@@ -14,7 +14,10 @@ tags: #fix #correctness
 ```grit
 language go
 
-`path.Join($params)` => `filepath.Join($params)`
+or {
+    `path.Join($params)` => `filepath.Join($params)`,
+    ensure_import(`"path/filepath"`)
+}
 ```
 
 ## Replace `path.Join()` ⇒ `filepath.Join()`
@@ -25,7 +28,6 @@ package main
 import (
 	"fmt"
 	"path"
-	"path/filepath"
 )
 
 func getDirectory() string {
@@ -53,6 +55,7 @@ func exampleFunction3(p string) {
 
 	fmt.Println(filepath.Join(a.Path, "baz"))
 }
+
 ```
 
 ```go
@@ -61,7 +64,7 @@ package main
 import (
 	"fmt"
 	"path"
-	"path/filepath"
+"path/filepath"
 )
 
 func getDirectory() string {
@@ -89,4 +92,5 @@ func exampleFunction3(p string) {
 
 	fmt.Println(filepath.Join(a.Path, "baz"))
 }
+
 ```

--- a/.grit/patterns/go/path_to_filepath.md
+++ b/.grit/patterns/go/path_to_filepath.md
@@ -6,7 +6,8 @@ Utilize `filepath.Join(...)` instead of `path.Join(...)` as it accommodates OS-s
 
 ### references
 
-- [strconv](https://pkg.go.dev/strconv)
+- [path.join-considered-harmful](https://parsiya.net/blog/2019-03-09-path.join-considered-harmful/)
+- [path.go](https://go.dev/src/path/path.go?s=4034:4066#L145)
 
 tags: #fix #correctness
 


### PR DESCRIPTION
Utilize `filepath.Join(...)` instead of `path.Join(...)` as it accommodates OS-specific path separators, mitigating potential issues on systems like Windows that may employ different delimiters.

### references

- [path.join-considered-harmful](https://parsiya.net/blog/2019-03-09-path.join-considered-harmful/)
- [path.go](https://go.dev/src/path/path.go?s=4034:4066#L145)

grit studio link: https://app.grit.io/studio?key=EcRvmSnLb7iBt1z5mzboh