### PR TITLE
feat: Detected wildcard access granted to sts:AssumeRole and limit to a specific identity in your account

### DIFF
--- a/.grit/patterns/json/wildcard_assume_role.md
+++ b/.grit/patterns/json/wildcard_assume_role.md
@@ -1,0 +1,150 @@
+---
+title: Detected wildcard access granted to sts:AssumeRole and limit to a specific identity in your account
+---
+
+# Auto-upgrade TypeScript
+
+Detected wildcard access granted to sts:AssumeRole. This means anyone with your AWS account ID and the name of the role can assume the role. Instead, limit to a specific identity in your account, like this: `arn:aws:iam::<account_id>:root`."
+
+### references
+
+- [aws](https://rhinosecuritylabs.com/aws/assume-worst-aws-assume-role-enumeration/)
+
+tags: #aws
+
+```grit
+language json
+
+`{
+    "Effect": $type,
+    $config,
+    "Action": "sts:AssumeRole"
+}` where {
+    $config <: contains `"Principal": { "AWS": $key }` where {
+        any {
+            if( $key <: contains `*` ){
+                $type <: contains `Allow` => `Deny`
+            },
+            if( $key <: contains `"arn:aws:iam::$account_id:root"`){
+                $type <: contains `Deny` => `Allow`
+            }
+        }
+    },
+}
+```
+
+## "AWS": "*"
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      // wildcard-assume-role
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "sts:AssumeRole"
+    },
+    {
+      "Effect": "Deny",
+      // wildcard-assume-role
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "sts:AssumeRole"
+    },
+    {
+      "Effect": "Allow",
+      // wildcard-assume-role
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "s3:PutObject"
+    }
+  ]
+}
+```
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Deny",
+      // wildcard-assume-role
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "sts:AssumeRole"
+    },
+    {
+      "Effect": "Deny",
+      // wildcard-assume-role
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "sts:AssumeRole"
+    },
+    {
+      "Effect": "Allow",
+      // wildcard-assume-role
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "s3:PutObject"
+    }
+  ]
+}
+```
+
+## "AWS": "arn:aws:iam::<account_id>:root"
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Deny",
+      // wildcard-assume-role
+      "Principal": {
+        "AWS": "arn:aws:iam::1234567890:root"
+      },
+      "Action": "sts:AssumeRole"
+    },
+    {
+      "Effect": "Allow",
+      // wildcard-assume-role
+      "Principal": {
+        "AWS": "arn:aws:iam::1234567890:root"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+```
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      // wildcard-assume-role
+      "Principal": {
+        "AWS": "arn:aws:iam::1234567890:root"
+      },
+      "Action": "sts:AssumeRole"
+    },
+    {
+      "Effect": "Allow",
+      // wildcard-assume-role
+      "Principal": {
+        "AWS": "arn:aws:iam::1234567890:root"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+```

--- a/.grit/patterns/json/wildcard_assume_role.md
+++ b/.grit/patterns/json/wildcard_assume_role.md
@@ -2,32 +2,27 @@
 title: Detected wildcard access granted to sts:AssumeRole and limit to a specific identity in your account
 ---
 
-# Auto-upgrade TypeScript
-
 Detected wildcard access granted to sts:AssumeRole. This means anyone with your AWS account ID and the name of the role can assume the role. Instead, limit to a specific identity in your account, like this: `arn:aws:iam::<account_id>:root`.
 
+tags: #aws
 ### references
 
 - [aws](https://rhinosecuritylabs.com/aws/assume-worst-aws-assume-role-enumeration/)
 
-tags: #aws
+
 
 ```grit
 language json
 
-`{
-    "Effect": $type,
-    $config,
+`{ 
+    "Effect": $type, 
+    $config, 
     "Action": "sts:AssumeRole"
 }` where {
     $config <: contains `"Principal": { "AWS": $key }` where {
-        any {
-            if( $key <: contains `*` ){
-                $type <: contains `Allow` => `Deny`
-            },
-            if( $key <: contains `"arn:aws:iam::$account_id:root"`){
-                $type <: contains `Deny` => `Allow`
-            }
+        $key <: contains or {
+            `*` where $type <: contains `Allow` => `Deny`,
+            `"arn:aws:iam::$account_id:root"` where $type <: contains `Deny` => `Allow`
         }
     },
 }

--- a/.grit/patterns/json/wildcard_assume_role.md
+++ b/.grit/patterns/json/wildcard_assume_role.md
@@ -4,7 +4,7 @@ title: Detected wildcard access granted to sts:AssumeRole and limit to a specifi
 
 # Auto-upgrade TypeScript
 
-Detected wildcard access granted to sts:AssumeRole. This means anyone with your AWS account ID and the name of the role can assume the role. Instead, limit to a specific identity in your account, like this: `arn:aws:iam::<account_id>:root`."
+Detected wildcard access granted to sts:AssumeRole. This means anyone with your AWS account ID and the name of the role can assume the role. Instead, limit to a specific identity in your account, like this: `arn:aws:iam::<account_id>:root`.
 
 ### references
 


### PR DESCRIPTION
Detected wildcard access granted to sts:AssumeRole. This means anyone with your AWS account ID and the name of the role can assume the role. Instead, limit to a specific identity in your account, like this: `arn:aws:iam::<account_id>:root`.

### references

- [aws](https://rhinosecuritylabs.com/aws/assume-worst-aws-assume-role-enumeration/)

grit studio link: https://app.grit.io/studio?key=FYBOCusMydFhnaYVM89eP