### PR TITLE
fix: frontmatter commas

### DIFF
--- a/.grit/patterns/js/_convert_default_exports.md
+++ b/.grit/patterns/js/_convert_default_exports.md
@@ -1,10 +1,9 @@
 ---
 title: Replace default exports with named exports
-tags: [syntax,, default,, export]
+tags: [syntax, default, export]
 ---
 
 Replaces `export default $something` with `export const $name = $something`. The chosen name matches the file name.
-
 
 ```grit
 language js

--- a/.grit/patterns/js/add_type_caught_errors.md
+++ b/.grit/patterns/js/add_type_caught_errors.md
@@ -1,12 +1,11 @@
 ---
 title: Add Type To Caught Errors
-tags: [js,, ts]
+tags: [js, ts]
 ---
 
 # Add Type To Caught Errors
 
 Add `any` type annotation to caught errors. It is a common source of tsc errors.
-
 
 ```grit
 engine marzano(1.0)

--- a/.grit/patterns/js/chai_to_jest.md
+++ b/.grit/patterns/js/chai_to_jest.md
@@ -1,10 +1,9 @@
 ---
 title: Chai to Jest
-tags: [migration,, js]
+tags: [migration, js]
 ---
 
 Convert Chai test assertions to Jest.
-
 
 ```grit
 engine marzano(0.1)

--- a/.grit/patterns/js/drizzle_mysql_postgresql.md
+++ b/.grit/patterns/js/drizzle_mysql_postgresql.md
@@ -1,10 +1,9 @@
 ---
 title: Convert Drizzle Schema from MySQL to PostgreSQL
-tags: [drizzle,, mysql,, postgresql]
+tags: [drizzle, mysql, postgresql]
 ---
 
-Migrate the Drizzle DB schema from MySQL to PostgreSQL. 
-
+Migrate the Drizzle DB schema from MySQL to PostgreSQL.
 
 ```grit
 `import $alias from "drizzle-orm/mysql-core"` => `import $alias from "drizzle-orm/pg-core"` where {
@@ -76,7 +75,7 @@ import {
   serial,
   smallint,
   varchar,
-} from "drizzle-orm/pg-core"
+} from 'drizzle-orm/pg-core';
 
 export const tableOne = pgTable('table', {
   id: serial('id').primaryKey().notNull(),

--- a/.grit/patterns/js/enforce_strict_equality_check.md
+++ b/.grit/patterns/js/enforce_strict_equality_check.md
@@ -1,12 +1,11 @@
 ---
 title: Non-strict `==` ⇒  strict `===`
-tags: [fix,, SD]
+tags: [fix SD]
 ---
 
 Convert non-strict equality checking, using `==`, to the strict version, using `===`.
 
 Details on [StackOverflow](https://stackoverflow.com/questions/359494/which-equals-operator-vs-should-be-used-in-javascript-comparisons).
-
 
 ```grit
 engine marzano(0.1)


### PR DESCRIPTION
The extra commas have broken parsing for all affected files, making titles stop working.