### PR TITLE
chore: only one flavor

### DIFF
--- a/.grit/patterns/js/add_try_catch_async_functions.md
+++ b/.grit/patterns/js/add_try_catch_async_functions.md
@@ -2,7 +2,7 @@
 
 ```grit
 engine marzano(0.1)
-language js(typescript,jsx)
+language js
 
 `async ($args) => { $body }` where {
     $body <: not contains `try`,


### PR DESCRIPTION
removes unnecessary flavor declaration from add_try_catch_async pattern