### PR TITLE
feat:  correct true comparison `($x = true)`

### DIFF
--- a/.grit/patterns/java/correct_true_comparison_operator.md
+++ b/.grit/patterns/java/correct_true_comparison_operator.md
@@ -1,0 +1,34 @@
+---
+title: Correct comparison operator `$x = true`
+tags: [good-practice]
+---
+
+Update redundant incorrect comparison `($x == true)` to achieve clearer code logic and avoid unnecessary repetition.
+
+```grit
+language java
+
+`if($var = true) { $body }` => `if($var == true) { $body }`, 
+```
+
+## $x = true
+
+```java
+class Bar {
+    void main() {
+        boolean myBoolean;
+        if (myBoolean = true) {
+            continue;
+        }
+    }
+}
+```
+
+```java
+class Bar {
+    void main() {
+        boolean myBoolean;
+        if(myBoolean == true) { continue; }
+    }
+}
+```

--- a/.grit/patterns/java/correct_true_comparison_operator.md
+++ b/.grit/patterns/java/correct_true_comparison_operator.md
@@ -3,12 +3,15 @@ title: Correct comparison operator `$x = true`
 tags: [good-practice]
 ---
 
-Update redundant incorrect comparison `($x == true)` to achieve clearer code logic and avoid unnecessary repetition.
+Assignment inside a condition is usually accidental, this is likely meant to be a comparison.
 
 ```grit
 language java
 
-`if($var = true) { $body }` => `if($var == true) { $body }`
+`$var = true` => `$var == true` where {
+	  $var <: within `if ($cond) { $body }`,
+	  $var <: within $cond,
+	}
 ```
 
 ## $x = true
@@ -28,7 +31,9 @@ class Bar {
 class Bar {
     void main() {
         boolean myBoolean;
-        if(myBoolean == true) { continue; }
+        if (myBoolean == true) {
+            continue;
+        }
     }
 }
 ```

--- a/.grit/patterns/java/correct_true_comparison_operator.md
+++ b/.grit/patterns/java/correct_true_comparison_operator.md
@@ -8,7 +8,7 @@ Update redundant incorrect comparison `($x == true)` to achieve clearer code log
 ```grit
 language java
 
-`if($var = true) { $body }` => `if($var == true) { $body }`, 
+`if($var = true) { $body }` => `if($var == true) { $body }`
 ```
 
 ## $x = true


### PR DESCRIPTION
Assignment inside a condition is usually accidental, this is likely meant to be a comparison.