### PR TITLE
feat: Correct comparison operator `$x = false`

### DIFF
--- a/.grit/patterns/java/correct_false_comparison_operator.md.md
+++ b/.grit/patterns/java/correct_false_comparison_operator.md.md
@@ -1,0 +1,34 @@
+---
+title: Correct comparison operator `$x = false`
+tags: [good-practice]
+---
+
+Update redundant incorrect comparison `($x == false)` to achieve clearer code logic and avoid unnecessary repetition.
+
+```grit
+language java
+
+`if($var = false) { $body }` => `if($var == false) { $body }`
+```
+
+## $x = true
+
+```java
+class Bar {
+    void main() {
+        boolean myBoolean;
+        if (myBoolean = false) {
+            continue;
+        }
+    }
+}
+```
+
+```java
+class Bar {
+    void main() {
+        boolean myBoolean;
+        if(myBoolean == false) { continue; }
+    }
+}
+```

--- a/.grit/patterns/java/correct_false_comparison_operator.md.md
+++ b/.grit/patterns/java/correct_false_comparison_operator.md.md
@@ -3,7 +3,7 @@ title: Correct comparison operator `$x = false`
 tags: [good-practice]
 ---
 
-Assignment inside a condition is usually accidental, this is likely meant to be a comparison.
+Assignment inside a condition like this `$x = false` is usually accidental, this is likely meant to be a comparison `$x == false`.
 
 ```grit
 language java

--- a/.grit/patterns/java/correct_false_comparison_operator.md.md
+++ b/.grit/patterns/java/correct_false_comparison_operator.md.md
@@ -3,12 +3,15 @@ title: Correct comparison operator `$x = false`
 tags: [good-practice]
 ---
 
-Update redundant incorrect comparison `($x == false)` to achieve clearer code logic and avoid unnecessary repetition.
+Assignment inside a condition is usually accidental, this is likely meant to be a comparison.
 
 ```grit
 language java
 
-`if($var = false) { $body }` => `if($var == false) { $body }`
+`$var = false` => `$var == false` where {
+	  $var <: within `if ($cond) { $body }`,
+	  $var <: within $cond,
+	}
 ```
 
 ## $x = true
@@ -28,7 +31,9 @@ class Bar {
 class Bar {
     void main() {
         boolean myBoolean;
-        if(myBoolean == false) { continue; }
+        if (myBoolean == false) {
+            continue;
+        }
     }
 }
 ```


### PR DESCRIPTION
Assignment inside a condition like this `$x = false` is usually accidental, this is likely meant to be a `$x`