### PR TITLE
fix: add missing variable in moment_to_date

### DIFF
--- a/.grit/patterns/js/moment-to-date-fns.grit
+++ b/.grit/patterns/js/moment-to-date-fns.grit
@@ -22,7 +22,7 @@ private pattern moment_arith_lhs_identifier($date, $method, $count, $specifier) 
 
 // Any call expression that returns a moment.js date or duration object.
 private pattern exp_returns_moment($exp) {
-  `$fn()` as $exp where {
+  `$fn($_)` as $exp where {
     $fn <: or {
       `moment`,
       `$_.duration`,


### PR DESCRIPTION
we would like to require empty fields in snippets to match by default. This change allows moment_to_date to match using this criteria