### PR TITLE
fix: add missing variable for warning-for-hardcoded-tmp-path

### DIFF
--- a/.grit/patterns/python/warning-for-hardcoded-tmp-path.md
+++ b/.grit/patterns/python/warning-for-hardcoded-tmp-path.md
@@ -14,7 +14,7 @@ language python
 
 or {
     `$file = open($url, $mode)`,
-    `with open($url, $mode) as $filePath:`
+    `with open($url, $mode) as $filePath: $body`
 } as $readPath  where {
     $url <: contains r"(^\/tmp.*)"($badString)
 } => `# BAD: hardcoded tmp path \n$readPath`


### PR DESCRIPTION
we would like to require empty fields in snippets to match by default. This change allows warning-for-hardcoded-tmp-path to match using this criteria