### PR TITLE
fix: add missing metavariable in temfile-without-flush

### DIFF
--- a/.grit/patterns/python/tempfile-without-flush.md
+++ b/.grit/patterns/python/tempfile-without-flush.md
@@ -15,7 +15,7 @@ language python
 `def $name(): $body` as $func where {
     $func <: contains or {
         `$f = $tempfile.NamedTemporaryFile($params)`,
-        `with $tempfile.NamedTemporaryFile($params) as $f:`
+        `with $tempfile.NamedTemporaryFile($params) as $f: $_`
     },
     $func <: not contains `$f.flush()`,
     $func <: not contains `$f.close()`,


### PR DESCRIPTION
we would like to require empty fields in snippets to match by default. This change allows tempfile-without-flush to match using this criteria