### PR TITLE
fix: add missing metavariable to py_no_debugger

### DIFF
--- a/.grit/patterns/python/py_no_debugger.md
+++ b/.grit/patterns/python/py_no_debugger.md
@@ -15,9 +15,9 @@ or {
   `import pdb` where $db = `pdb`
 } where {
     $program <: maybe contains or {
-        `$db.set_trace()` => .,
-        `$db.Pdb.set_trace()` => .,
-        `$pdb.Pdb.set_trace()` => .,
+        `$db.set_trace($_)` => .,
+        `$db.Pdb.set_trace($_)` => .,
+        `$pdb.Pdb.set_trace($_)` => .,
     }
 }
 ```


### PR DESCRIPTION
we would like to require empty fields in snippets to match by default. This change allows py_no_debugger to match using this criteria