### PR TITLE
fix: add missing metavariable to collection_to_bool

### DIFF
--- a/.grit/patterns/python/collection_to_bool.md
+++ b/.grit/patterns/python/collection_to_bool.md
@@ -9,9 +9,9 @@ engine marzano(0.1)
 language python
 
 or {
-    `if $cond:`,
+    `if $cond: $_`,
     elif_clause(condition=$cond),
-    `while $cond:`,
+    `while $cond: $_`,
 } where $cond <: or {
     `[$elms]` as $arr where {
         $elms <: or {


### PR DESCRIPTION
we would like to require empty fields in snippets to match by default. This change allows collection_to_bool to match using this criteria