### PR TITLE
fix: add missing metavariable to open_file_object_never_closed

### DIFF
--- a/.grit/patterns/python/open_file_object_never_closed.md
+++ b/.grit/patterns/python/open_file_object_never_closed.md
@@ -12,7 +12,7 @@ We should close the file object opened without corresponding close.
 engine marzano(0.1)
 language python
 
-`def $func():` as $function where {
+`def $func(): $_` as $function where {
     and {
         $function <: contains or {
                 `$f = open($parms)`,


### PR DESCRIPTION
we would like to require empty fields in snippets to match by default. This change allows open_file_object_never_closed to match using this criteria