### PR TITLE
feat: add a simple Cargo.toml transform

### DIFF
--- a/.grit/patterns/rust/cargo_use_long_dependency.md
+++ b/.grit/patterns/rust/cargo_use_long_dependency.md
@@ -7,9 +7,10 @@ language toml
 
 `[dependencies]
 $deps` where {
+  $filename <: or { includes "Cargo.toml", includes "cargo.toml" },
   $deps <: some bubble `$name = $version` where {
     $version <: string(),
-    $version => `{ version = $version }`
+    $version => `{ version = $version }`,
   }
 }
 ```

--- a/.grit/patterns/rust/cargo_use_long_dependency.md
+++ b/.grit/patterns/rust/cargo_use_long_dependency.md
@@ -3,6 +3,15 @@
 In Cargo.toml files, switch from `name = version` to `name = { version = version }` to make it easier to read and maintain dependencies.
 
 ```grit
+language toml
+
+`[dependencies]
+$deps` where {
+  $deps <: some bubble `$name = $version` where {
+    $version <: string(),
+    $version => `{ version = $version }`
+  }
+}
 ```
 
 ## Basic example
@@ -17,7 +26,7 @@ name = "my-package"
 rand = "0.6"
 serde = { version = "1.0" }
 openssl = { version = "0.10" }
-other_old = "0.1.3"
+other_pkg = "0.1.3"
 ```
 
 New syntax, with all dependencies using the same format:
@@ -30,7 +39,7 @@ name = "my-package"
 rand = { version = "0.6" }
 serde = { version = "1.0" }
 openssl = { version = "0.10" }
-other_new = { version = "0.1.3" }
+other_pkg = { version = "0.1.3" }
 ```
 
 ## Ignore non-Cargo.toml files

--- a/.grit/patterns/rust/cargo_use_long_dependency.md
+++ b/.grit/patterns/rust/cargo_use_long_dependency.md
@@ -1,0 +1,50 @@
+# Avoid version shorthand for dependencies
+
+In Cargo.toml files, switch from `name = version` to `name = { version = version }` to make it easier to read and maintain dependencies.
+
+```grit
+```
+
+## Basic example
+
+Old syntax, with a mix of both:
+```toml
+// @filename: Cargo.toml
+[package]
+name = "my-package"
+
+[dependencies]
+rand = "0.6"
+serde = { version = "1.0" }
+openssl = { version = "0.10" }
+other_old = "0.1.3"
+```
+
+New syntax, with all dependencies using the same format:
+```toml
+// @filename: Cargo.toml
+[package]
+name = "my-package"
+
+[dependencies]
+rand = { version = "0.6" }
+serde = { version = "1.0" }
+openssl = { version = "0.10" }
+other_new = { version = "0.1.3" }
+```
+
+## Ignore non-Cargo.toml files
+
+This rule only applies to Cargo.toml files, so it's safe to ignore other files.
+
+```toml
+// @filename: other-file.toml
+[dependencies]
+rand = "0.6"
+```
+
+```toml
+// @filename: other-file.toml
+[dependencies]
+rand = "0.6"
+```


### PR DESCRIPTION
I often prefer to switch to this syntax since it makes everything uniform and makes versions easy to toggle.