### PR TITLE
fix: re_match_walrus pads incorrectly

### DIFF
--- a/.grit/patterns/python/re_match_walrus.md
+++ b/.grit/patterns/python/re_match_walrus.md
@@ -47,14 +47,16 @@ if_statement($alternative, $condition, $consequence) as $if where {
     },
     $condition <: `$var` => `$var := $match_func($regex)`,
     if ($alternative <: "") {
-        $block = $consequence,
+        $if => `if $condition:
+    $consequence`
     }
     else {
         $separator = `\n`,
-        $block = join(list = [$consequence, $alternative], $separator),
+        $if => `if $condition:
+    $consequence
+$alternative`
     }
-} => `if $condition:
-    $block`
+}
 
 ```
 


### PR DESCRIPTION
re_match_walrus relies on join not distributing indents, this removes this assumption