### PR TITLE
Fix minor typos in patterns

### DIFF
--- a/.grit/patterns/js/curly.md
+++ b/.grit/patterns/js/curly.md
@@ -37,7 +37,7 @@ if (x > 0) {
 }
 ```
 
-##else 
+## else 
 ```js 
 if (x > 0)
   doStuff();

--- a/.grit/patterns/js/replaceAll_to_replace.md
+++ b/.grit/patterns/js/replaceAll_to_replace.md
@@ -3,7 +3,7 @@ title: Rewrite `replaceAll` ⇒ `replace` when have regex pattern
 tags: [fix]
 ---
 
-Replaces `replaceAll` with `replace`, when have regex pattern.
+Replaces `replaceAll` with `replace`, when it uses a regex pattern.
 
 The `replaceAll` string method may not be supported in all JavaScript versions and older browsers. It is advisable to use the `replace()` method with a regular expression as the first argument. For example, use `mystring.replace(/bad/g, "good") `instead of `mystring.replaceAll("bad", "good")`
 

--- a/.grit/patterns/js/useless_ternary_operator.md
+++ b/.grit/patterns/js/useless_ternary_operator.md
@@ -3,7 +3,7 @@ title: Find useless ternary operator
 tags: [fix]
 ---
 
-If $condition ? `$answer`:`$answer` then this expression returns $answer. This is probably a human error
+If $condition ? `$answer`:`$answer` then this expression returns $answer. This is probably a human error.
 
 
 ```grit


### PR DESCRIPTION
Just getting my feet wet learning `gritql` and going through the example JS/TS patterns, I noticed some minor typos.

Following the contributing guidelines, I ran `grit patterns test` locally and got `198 out of 611 samples failed` which seems unrelated to this PR.