### PR TITLE
feat: implement pattern to replace `React` default import method references with destuctured named imports

### DIFF
--- a/.grit/patterns/js/react_named_imports.md
+++ b/.grit/patterns/js/react_named_imports.md
@@ -1,0 +1,65 @@
+---
+title: Replace React default imports with destructured named imports
+tags: [import, react, global]
+---
+
+This pattern replaces React default import method references (e.g. `React.ReactNode`) with destructured named imports (`import { ReactNode } from 'react'`).
+Running this will also make sure that `React` is imported.
+
+```grit
+engine marzano(0.1)
+language js(jsx)
+
+`React.$reactImport` where {
+    $reactImport <: ensure_import_from(`"react"`),
+} => `$reactImport`
+```
+
+## Replace method on React default import
+
+Given the following interface with `React` global:
+
+```typescript
+import React from 'react';
+
+interface MyComponentProps {
+  children: React.ReactNode;
+  anotherProp?: boolean;
+}
+```
+
+The result should import the relevant module:
+
+```typescript
+import React from 'react';
+import { ReactNode } from 'react';
+
+interface MyComponentProps {
+  children: ReactNode;
+  anotherProp?: boolean;
+}
+```
+
+Patterns such as `unused_imports` can be used to clean up the duplicate import.
+
+## Replace React global
+
+Given the following interface with `React` global:
+
+```typescript
+interface MyComponentProps {
+  children: React.ReactNode;
+  anotherProp?: boolean;
+}
+```
+
+The result should import the relevant module:
+
+```typescript
+import { ReactNode } from 'react';
+
+interface MyComponentProps {
+  children: ReactNode;
+  anotherProp?: boolean;
+}
+```


### PR DESCRIPTION
## Description

This pattern replaces React default import method references (e.g. `React.ReactNode`) with _destructured named imports_ (`import { ReactNode } from 'react'`).

Running this will also make sure that `React` is imported.

### Background

_This is mainly a pattern is used on my current code base, but I hope it can be useful to others._

Using the _destructured named imports_ is the recommended way to use React imports.

When this pattern is used in combination with a linter/ formatter (e.g. `Biome`) you can easily optimize legacy React code bases.

### Caveat 

This pattern always adds a new import when there is non-destructured import (if your coding style requires it) e.g.
```ts
// this:
import React from 'react';
import { ReactNode } from 'react';
// instead of this:
import React, { ReactNode } from 'react';
```
Additionally, if you are using typed imports you may need to rely on your linter.